### PR TITLE
network: add support for linux

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -7,11 +7,32 @@
 
 get_ssid()
 {
-	if /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2 &> /dev/null; then
-		echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)"
-	else
-		echo ' Ethernet'
-	fi
+	# Check OS
+	case $(uname -s) in
+		Linux)
+			if iw dev | grep ssid | cut -d ' ' -f 2 &> /dev/null; then
+				echo $(iw dev | grep ssid | cut -d ' ' -f 2)
+			else
+				echo ' Ethernet'
+			fi
+		;;
+
+		Darwin)
+			if /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2 &> /dev/null; then
+				echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)"
+			else
+				echo ' Ethernet'
+			fi
+		;;
+
+		CYGWIN*|MINGW32*|MSYS*|MINGW*)
+			# leaving empty - TODO - windows compatability
+		;;
+
+		*)
+		;;
+	esac
+
 }
 
 main()


### PR DESCRIPTION
## Description

This change adds support for network name and status on Linux. It first checks the operating system used, and then runs an appropriate command or commands.

## Evaluation

I tested this on Linux 5.5.9 - `5.5.9-arch1-2`. All commands used should be part of a standard Linux install, and the directory `/sys/class/power_supply/BAT0/` should also be standard. 
