### PR TITLE
[Feature] Provides ability to disable weather fetching and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ All instructions can be found at [draculatheme.com/tmux](https://draculatheme.co
 
 Compatible with macOS and Linux. Tested on tmux 3.0a
 
+## Options
+
+### `@dracula-show-weather`
+
+The weather module can be disabled by adding the following line to your
+`~/.tmux.conf`:
+
+```
+set -g @dracula-show-weather false
+```
+
 ## Team
 
 This theme is maintained by the following person(s) and a bunch of [awesome contributors](https://github.com/dracula/tmux/graphs/contributors).

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -3,10 +3,22 @@
 # a tmux color scheme inspired by dracula
 # author: Dane Williams
 
+get_tmux_option() {
+  local option=$1
+  local default_value=$2
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z $option_value ]; then
+    echo $default_value
+  else
+    echo $option_value
+  fi
+}
+
 main()
 {
   # set current directory variable
   current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  show_weather=$(get_tmux_option "@dracula-show-weather" true)
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -22,7 +34,9 @@ main()
   yellow='#f1fa8c'
 
   # start weather script in background
-  $current_dir/sleep_weather.sh &
+  if $show_weather; then
+    $current_dir/sleep_weather.sh &
+  fi
 
   # set refresh interval
   tmux set-option -g status-interval 5
@@ -48,7 +62,9 @@ main()
 
   tmux set-option -g  status-right "#[fg=${dark_gray},bg=${pink}] #($current_dir/battery.sh) "
   tmux set-option -ga status-right "#[fg=${dark_gray},bg=${cyan}]#($current_dir/network.sh) "
-  tmux set-option -ga status-right "#[fg=${dark_gray},bg=${orange}] #(cat $current_dir/../data/weather.txt) " 
+  if $show_weather; then
+    tmux set-option -ga status-right "#[fg=${dark_gray},bg=${orange}] #(cat $current_dir/../data/weather.txt) " 
+  fi
   tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p #(date +%Z) "
   
   # window tabs 


### PR DESCRIPTION
Personally, displaying the weather doesn't have a lot of use for me
but additionally I ran into an issue where the API you are using
ratelimited call from my IP address, I guess because it was
overfetching.

This doesn't fix the ratelimited issue, but instead at least gives
people the ability to turn the feature off.

Test Plan:

In `~/.tmux.conf` set the following:

```
set -g @plugin 'tmux-plugins/tpm'
set -g @dracula-show-weather false
set -g @plugin 'camspiers/tmux'
run -b '~/.local/share/tmux/plugins/tpm/tpm'
```

Ensure that weather module no longer loads.

In `~/.tmux.conf` set the following:

```
set -g @plugin 'tmux-plugins/tpm'
set -g @dracula-show-weather true
set -g @plugin 'camspiers/tmux'
run -b '~/.local/share/tmux/plugins/tpm/tpm'
```

Ensure that weather module does stil load.