### PR TITLE
Added option to change the smiley face

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -1,13 +1,39 @@
 #!/usr/bin/env bash
+linux_acpi() {
+    arg=$1
+    BAT=$(ls -d /sys/class/power_supply/BAT* | head -1)
+    if [ ! -x "$(which acpi 2> /dev/null)" ];then
+        case "$arg" in
+            status)
+                cat $BAT/status
+            ;;
 
-BAT=$(ls /sys/class/power_supply/BAT* | head -1)
+            percent)
+                cat $BAT/capacity
+            ;;
 
+            *)
+            ;;
+        esac
+    else
+        case "$arg" in
+            status)
+                acpi | cut -d: -f2- | cut -d, -f1 | tr -d ' '
+            ;;
+            percent)
+                acpi | cut -d: -f2- | cut -d, -f2 | tr -d '% '
+            ;;
+            *)
+            ;;
+        esac
+    fi
+}
 battery_percent()
 {
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			cat $BAT/capacity
+            linux_acpi percent
 		;;
 
 		Darwin)
@@ -28,7 +54,7 @@ battery_status()
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			status=$(cat $BAT/status)
+            status=$(linux_acpi status)
 		;;
 
 		Darwin)
@@ -43,7 +69,7 @@ battery_status()
 		;;
 	esac
 
-	if [ $status = 'discharging' ] || [ $status = 'Discharging' ]; then
+	if [ "$status" = "discharging" ] || [ "$status" = "Discharging" ]; then
 		echo ''
 	else
 	 	echo 'AC '

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -40,9 +40,9 @@ main()
   
   case $show_left_icon in
       smiley)
-          left_icon="☺";;
+          left_icon="☺ ";;
       session)
-          left_icon="#W";;
+          left_icon="#W ";;
       *)
           left_icon=$show_left_icon;;
   esac

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -21,6 +21,7 @@ main()
   show_weather=$(get_tmux_option "@dracula-show-weather" true)
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
+  show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -35,6 +36,15 @@ main()
   pink='#ff79c6'
   yellow='#f1fa8c'
   
+  case $show_left_icon in
+      smiley)
+          left_icon="☺";;
+      session)
+          left_icon="#W";;
+      *)
+          left_icon=$show_left_icon;;
+  esac
+
   if $show_powerline; then
       right_sep=''
       left_sep=''
@@ -66,7 +76,7 @@ main()
 
   if $show_powerline; then
 
-      tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ☺  #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}        " 
+      tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
       tmux set-option -g  status-right ""
       powerbg=${gray}
 
@@ -89,7 +99,7 @@ main()
       # window tabs 
       tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W #[fg=${dark_purple},bg=${gray}]${left_sep}"
   else
-    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ☺ " 
+    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
 
     tmux set-option -g  status-right ""
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -23,7 +23,8 @@ main()
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
   show_military=$(get_tmux_option "@dracula-military-time" false)
-
+  show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
+  show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
   # Dracula Color Pallette
   white='#f8f8f2'
   gray='#44475a'
@@ -47,8 +48,8 @@ main()
   esac
 
   if $show_powerline; then
-      right_sep=''
-      left_sep=''
+      right_sep="$show_right_sep"
+      left_sep="$show_left_sep"
   fi
   # start weather script in background
   if $show_weather; then


### PR DESCRIPTION
rewrote a function in battery.sh to make use of acpi command in linux if it exists or else fallback to /sys/class/power_supply/BAT*
added option to switch powerline separators
added option to switch the smiley face with window name or any other character issue #14 
