### PR TITLE
Fix Linux implementation of battery.sh

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-BAT=$(ls /sys/class/power_supply/BAT* | head -1)
-
 battery_percent()
 {
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			cat $BAT/capacity
+			cat /sys/class/power_supply/BAT0/capacity
 		;;
 
 		Darwin)
@@ -28,7 +26,7 @@ battery_status()
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			status=$(cat $BAT/status)
+			status=$(cat /sys/class/power_supply/BAT0/status)
 		;;
 
 		Darwin)
@@ -43,7 +41,7 @@ battery_status()
 		;;
 	esac
 
-	if [ $status = 'discharging' ] || [ $status = 'Discharging' ]; then
+	if [[ $status = 'discharging' ]] || [[ $status = 'Discharging' ]]; then
 		echo ''
 	else
 	 	echo 'AC '


### PR DESCRIPTION
The original implementation attempted to automatically detect the default battery. Since that technique is error prone (I encountered the same issue), I've removed it in an attempt to resolve #25.

My bash syntax checker also complained about the equality comparison on line 44, so I cleaned that up as well.