### PR TITLE
Add option to enable high contrast on pane borders

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,3 +23,4 @@ Customize the status bar by adding any of these lines to your .tmux.conf as desi
 * Switch powerline symbols `set -g @dracula-show-left-sep ` for left and `set -g @dracula-show-right-sep ` for right symbol (can set any symbol you like as seperator)
 * Enable military time: `set -g @dracula-military-time true`
 * Switch the left smiley icon `set -g @dracula-show-left-icon session` it can accept `session`, `smiley`, or any character.
+* Enable high contrast pane border: `set -g @dracula-border-contrast true`

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -25,6 +25,7 @@ main()
   show_military=$(get_tmux_option "@dracula-military-time" false)
   show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
   show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
+  show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
   # Dracula Color Pallette
   white='#f8f8f2'
   gray='#44475a'
@@ -67,7 +68,12 @@ main()
   tmux set-option -g status-right-length 100
 
   # pane border styling
-  tmux set-option -g pane-active-border-style "fg=${dark_purple}"
+  if $show_border_contrast; then
+    tmux set-option -g pane-active-border-style "fg=${light_purple}"
+  else
+    tmux set-option -g pane-active-border-style "fg=${dark_purple}"
+  fi
+
   tmux set-option -g pane-border-style "fg=${gray}"
 
   # message styling


### PR DESCRIPTION
Sometimes, when several panels are open, it is difficult to know which panel is active due to the low contrast of the _dark_purple_ color in the _purple_ background.
So I implemented a simple option that changes the color to _light_purple_ when the `@dracula-border-contrast` flag is `true` (the default is `false` when the flag has not been set).