### PR TITLE
Improve wireless detection when interface is down

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -7,8 +7,9 @@ get_ssid()
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			if iw dev | grep ssid | cut -d ' ' -f 2 &> /dev/null; then
-				echo "$(iw dev | grep ssid | cut -d ' ' -f 2)"
+			SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+			if [ -n "$SSID" ]; then
+				echo -- "$SSID"
 			else
 				echo 'Ethernet'
 			fi

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -9,7 +9,7 @@ get_ssid()
 		Linux)
 			SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
 			if [ -n "$SSID" ]; then
-				echo -- "$SSID"
+				printf '%s' "$SSID"
 			else
 				echo 'Ethernet'
 			fi


### PR DESCRIPTION
When using redirection to filter the output of the `iw dev` command (commit b3614321da36c7124f76ecde9aa18a590e684ddb), the return value of the command is affected, so the output will never be **Ethernet**.

Another problem is associated when there is a connection via Ethernet but a wireless adapter is present but not connected, resulting in an empty output.

I fixed this problem by analyzing the filter output instead of the `iw dev` return code. If it is empty, either the Wi-Fi is not connected or there is no adapter present; otherwise, **Ethernet** is displayed.

The use of `printf` is necessary if the SSID starts with dashes (_-_) or with a percent sign (_%_).