### PR TITLE
Prevent multiple instances of sleep_weather.sh from running simultaneously

### DIFF
--- a/scripts/sleep_weather.sh
+++ b/scripts/sleep_weather.sh
@@ -4,12 +4,23 @@
 
 fahrenheit=$1
 
+LOCKFILE=/tmp/.dracula-tmux-weather.lock
+
+ensure_single_process()
+{
+	# check for another running instance of this script and terminate it if found
+	[ -f $LOCKFILE ] && ps -p "$(cat $LOCKFILE)" -o cmd= | grep -F " ${BASH_SOURCE[0]}" && kill "$(cat $LOCKFILE)"
+	echo $$ > $LOCKFILE
+}
+
 main()
 {
+	ensure_single_process
+
 	current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 	$current_dir/weather.sh > $current_dir/../data/weather.txt
-	
+
 	while tmux has-session &> /dev/null
 	do
 		$current_dir/weather.sh $fahrenheit > $current_dir/../data/weather.txt
@@ -20,6 +31,8 @@ main()
 			break
 		fi
 	done
+
+	rm $LOCKFILE
 }
 
 #run main driver function


### PR DESCRIPTION
If the theme/tmux config is reloaded, a new instance of `sleep_weather.sh` will be spawned without first checking if another instance is already running. This results in unnecessary use of system resources and may cause users to quickly hit their daily API limit. This PR would fix the issue by checking for an existing instance of the script and terminating it if found.

It may be advisable for existing users to run `kill $(pgrep -f 'bash .*/sleep_weather.sh')` and then reload their config to ensure that only one instance is running.

### Steps to Reproduce
1. Open tmux with the theme enabled
2. Count the number of running processes with `pgrep -af 'bash .*/sleep_weather.sh'`
3. Reload the theme/tmux config (`prefix` + `:source-file ~/.tmux.conf`)
4. Perform step 2 again and compare the output

### Screenshots
Output before and after reloading the tmux config multiple times:
![dracula-processes](https://user-images.githubusercontent.com/13055788/89135036-47373600-d4f8-11ea-89bf-6fddb5ba7330.png)

