### PR TITLE
Support multi-gpu environment

### DIFF
--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -4,7 +4,7 @@ get_platform()
 {
 	case $(uname -s) in
 		Linux)
-			gpu=$(lspci -v | grep -i gpu | grep driver | awk '{print $5}')
+			gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
 			echo $gpu
 		;;
 
@@ -20,10 +20,12 @@ get_platform()
 get_gpu()
 {
 	gpu=$(get_platform)
-	if [ $gpu == nvidia-gpu ]; then
-		usage=$(nvidia-smi | grep "%" | awk '{print $13}')
-		echo $usage
+	if [[ "$gpu" == NVIDIA ]]; then
+    usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
+  else
+    usage='unknown'
 	fi
+  echo $usage
 }
 main()
 {
@@ -33,5 +35,3 @@ main()
 }
 # run the main driver
 main
-
-


### PR DESCRIPTION
Did the following:
1. Support homogeneous-vendor multi-GPU machines. Utilization values are simply averaged.
2. Grepping with `VGA` is more general.
3. Print `GPU unknown` for other GPU vendors.

Tested on my desktop (one NVIDIA GPU, Ubuntu bionic), and my lab server (six NVIDIA GPUs, Ubuntu bionic).