### PR TITLE
Add flag for dd/mm date format that works with military time.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,3 +28,4 @@ Customize the status bar by adding any of these lines to your .tmux.conf as desi
 * Enable cpu usage: `set -g @dracula-cpu-usage true`
 * Enable ram usage: `set -g @dracula-ram-usage true`
 * Enable gpu usage: `set -g @dracula-gpu-usage true`
+* Swap date to day/month `set -g @dracula-day-month true`

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -31,6 +31,7 @@ main()
   show_cpu_usage=$(get_tmux_option "@dracula-cpu-usage" false)
   show_ram_usage=$(get_tmux_option "@dracula-ram-usage" false)
   show_gpu_usage=$(get_tmux_option "@dracula-gpu-usage" false)
+  show_day_month=$(get_tmux_option "@dracula-day-month" false)
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -139,10 +140,14 @@ main()
         powerbg=${orange}
       fi
 
-      if $show_military; then # military time
-	tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
+      if $show_day_month && $show_military ; then # military time and dd/mm
+        tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %d/%m %R ${timezone} "
+      elif $show_military; then # only military time
+        tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
+      elif $show_day_month; then # only dd/mm
+        tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %d/%m %I:%M %p ${timezone} "
       else
-	tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
+        tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
       fi
 
       tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W #[fg=${dark_purple},bg=${gray}]${left_sep}"
@@ -176,10 +181,14 @@ main()
           tmux set-option -ga status-right "#[fg=${dark_gray},bg=${orange}] #(cat $current_dir/../data/weather.txt) "
       fi
 
-      if $show_military; then # military time
-	tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
+      if $show_day_month && $show_military ; then # military time and dd/mm
+        tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %d/%m %R ${timezone} "
+      elif $show_military; then # only military time
+        tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
+      elif $show_day_month; then # only dd/mm
+        tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %d/%m %I:%M %p ${timezone} "
       else
-	tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
+        tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
       fi
 
       tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W "


### PR DESCRIPTION
This adds a setting to allow changing the date `mm/dd` format on the right status to a `dd/mm` format on as used in countries like the UK. This works in tandem with the military time setting. I've tested only the non-powerline version thanks to terminal limitations but should cover powerline users too.