### PR TITLE
Specify numeric locale for parsing top output

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -4,7 +4,7 @@ get_percent()
 {
 	case $(uname -s) in
 		Linux)
-			percent=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+			percent=$(LC_NUMERIC=en_US.UTF-8 top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
 			echo $percent
 		;;
 		


### PR DESCRIPTION
My locale is set to `nl_NL.UTF-8`, and it uses comma as a decimal separator and breaks the parsing of top output.

This change uses US locale which will generate output with point as a decimal separator.