### PR TITLE
Show all GPU stats in multi-GPU environment

### DIFF
--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -32,8 +32,13 @@ get_platform()
 get_gpu()
 {
 	gpu=$(get_platform)
+	expand=$(get_tmux_option "@dracula-gpu-expand" true)
 	if [[ "$gpu" == NVIDIA ]]; then
-    usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{if ($1 < 10) {print "0"$1"%"} else {print $1"%"}}')
+		if $expand; then
+			usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{if ($1 < 10) {print "0"$1"%"} else {print $1"%"}}')
+		else
+			usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { mean = sum / NR; if (mean < 10) {printf("0%d%%\n", mean)} else {printf("%d%%\n", mean)}}') 
+		fi
   else
     usage='unknown'
 	fi

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -32,12 +32,13 @@ get_platform()
 get_gpu()
 {
 	gpu=$(get_platform)
-	expand=$(get_tmux_option "@dracula-gpu-expand" true)
+	expand="$1"
 	if [[ "$gpu" == NVIDIA ]]; then
+		utils=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits)
 		if $expand; then
-			usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{printf("%02d%% ", $1)}')
+			usage=$(echo "$utils" | awk '{printf("%02d%% ", $1)}')
 		else
-			usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { mean = sum / NR; printf("%02d%%\n", mean)}') 
+			usage=$(echo "$utils" | awk '{sum += $1} END {printf("%02d%%\n", sum/NR)}') 
 		fi
   else
     usage='unknown'
@@ -48,7 +49,8 @@ main()
 {
 	# storing the refresh rate in the variable RATE, default is 5
 	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-	gpu_usage=$(get_gpu)
+	EXPAND=$(get_tmux_option "@dracula-gpu-expand" true)
+	gpu_usage=$(get_gpu $EXPAND)
 	echo "GPU $gpu_usage"
 	sleep $RATE
 }

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -35,9 +35,9 @@ get_gpu()
 	expand=$(get_tmux_option "@dracula-gpu-expand" true)
 	if [[ "$gpu" == NVIDIA ]]; then
 		if $expand; then
-			usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{if ($1 < 10) {print "0"$1"%"} else {print $1"%"}}')
+			usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{printf("%02d%% ", $1)}')
 		else
-			usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { mean = sum / NR; if (mean < 10) {printf("0%d%%\n", mean)} else {printf("%d%%\n", mean)}}') 
+			usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { mean = sum / NR; printf("%02d%%\n", mean)}') 
 		fi
   else
     usage='unknown'

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -33,7 +33,7 @@ get_gpu()
 {
 	gpu=$(get_platform)
 	if [[ "$gpu" == NVIDIA ]]; then
-    usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
+    usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{if ($1 < 10) {print "0"$1"%"} else {print $1"%"}}')
   else
     usage='unknown'
 	fi


### PR DESCRIPTION
**Context**
- Currently, in multi-GPU environments, Dracula shows the average utilization of all GPUs (I did that in #58). Yet, I believe it is better to show the utilization of all GPUs.

**Major Changes**
- For multi-GPU environments, refer to the following screenshot. Things are the same for single-GPU environments.

<img width="698" alt="스크린샷 2020-09-17 오전 12 04 52" src="https://user-images.githubusercontent.com/29395896/93356175-d2d30f00-f879-11ea-99e6-8f0e50b31818.png">

**Comments**
- I fixed all utilization percents to show two digits so that the length of the plugin bar doesn't fluctuate. This means that if the utilization is under 10%, it will be prefixed by one zero.