### PR TITLE
47: Enable window flags with `set -g @dracula-show-flags true`.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ Customize the status bar by adding any of these lines to your .tmux.conf as desi
 * Switch from default fahrenheit to celsius: `set -g @dracula-show-fahrenheit false`
 * Enable powerline symbols: `set -g @dracula-show-powerline true`
 * Switch powerline symbols `set -g @dracula-show-left-sep ` for left and `set -g @dracula-show-right-sep ` for right symbol (can set any symbol you like as seperator)
+* Enable window flags: `set -g @dracula-show-flags true`
 * Adjust the refresh rate for the bar `set -g @dracula-refresh-rate 5` the default is 5, it can accept any number
 * Enable military time: `set -g @dracula-military-time true`
 * Disable timezone: `set -g @dracula-show-timezone false`

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -22,6 +22,7 @@ main()
   show_weather=$(get_tmux_option "@dracula-show-weather" true)
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
+  show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
   show_military=$(get_tmux_option "@dracula-military-time" false)
   show_timezone=$(get_tmux_option "@dracula-show-timezone" true)
@@ -47,7 +48,7 @@ main()
   red='#ff5555'
   pink='#ff79c6'
   yellow='#f1fa8c'
-  
+
 
   # Handle left icon configuration
   case $show_left_icon in
@@ -80,13 +81,22 @@ main()
           timezone="#(date +%Z)";;
   esac
 
+  case $show_flags in
+    false)
+      flags=""
+      current_flags="";;
+    true)
+      flags="#{?window_flags,#[fg=${dark_purple}]#{window_flags},}"
+      current_flags="#{?window_flags,#[fg=${light_purple}]#{window_flags},}"
+  esac
+
   # sets refresh interval to every 5 seconds
   tmux set-option -g status-interval $show_refresh
 
   # set clock to 12 hour by default
   tmux set-option -g clock-mode-style 12
 
-  # set length 
+  # set length
   tmux set-option -g status-left-length 100
   tmux set-option -g status-right-length 100
 
@@ -135,7 +145,7 @@ main()
       if $show_gpu_usage; then
 	 tmux set-option -ga status-right "#[fg=${pink},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${pink}] #($current_dir/gpu_usage.sh)"
 	 powerbg=${pink}
-      fi	
+      fi
 
       if $show_network; then # network
         tmux set-option -ga status-right "#[fg=${cyan},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${cyan}] #($current_dir/network.sh)"
@@ -159,8 +169,8 @@ main()
         fi
       fi
 
-      tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W #[fg=${dark_purple},bg=${gray}]${left_sep}"
-  
+      tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
+
   # Non Powerline Configuration
   else
     tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
@@ -180,7 +190,7 @@ main()
 
       if $show_gpu_usage; then
 	tmux set-option -ga status-right "#[fg=${dark_gray},bg=${pink}] #($current_dir/gpu_usage.sh) "
-      fi	
+      fi
 
       if $show_network; then # network
         tmux set-option -ga status-right "#[fg=${dark_gray},bg=${cyan}] #($current_dir/network.sh) "
@@ -202,11 +212,13 @@ main()
         fi
       fi
 
-      tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W "
+      tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
 
   fi
-  
-  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W "
+
+  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W${flags}"
+  tmux set-window-option -g window-status-activity-style "bold"
+  tmux set-window-option -g window-status-bell-style "bold"
 }
 
 # run main function


### PR DESCRIPTION
Enbolden window titles on activity or bell status.  This is more readable, IMO, than the default reverse text, especially when window flags appear in different colors.