### PR TITLE
Add an option to disable the location information in the weather

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -21,6 +21,7 @@ main()
   show_network=$(get_tmux_option "@dracula-show-network" true)
   show_weather=$(get_tmux_option "@dracula-show-weather" true)
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
+  show_location=$(get_tmux_option "@dracula-show-location" true)
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
@@ -70,7 +71,7 @@ main()
 
   # start weather script in background
   if $show_weather; then
-    $current_dir/sleep_weather.sh $show_fahrenheit &
+    $current_dir/sleep_weather.sh $show_fahrenheit $show_location &
   fi
 
   # Set timezone unless hidden by configuration

--- a/scripts/sleep_weather.sh
+++ b/scripts/sleep_weather.sh
@@ -3,6 +3,7 @@
 #wrapper script for running weather on interval
 
 fahrenheit=$1
+location=$2
 
 LOCKFILE=/tmp/.dracula-tmux-weather.lock
 
@@ -27,7 +28,7 @@ main()
 
 	while tmux has-session &> /dev/null
 	do
-		$current_dir/weather.sh $fahrenheit > $current_dir/../data/weather.txt
+		$current_dir/weather.sh $fahrenheit $location > $current_dir/../data/weather.txt
 		if tmux has-session &> /dev/null
 		then
 			sleep 1200

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -18,7 +18,7 @@ fetch_weather_information()
 {
 	display_weather=$1
 	# it gets the weather condition textual name (%C), and the temperature (%t)
-	curl -sL wttr.in\?format="+%C+%t$display_weather"
+	curl -sL wttr.in\?format="%C+%t$display_weather"
 }
 
 #get weather display

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -17,7 +17,7 @@ display_location()
 fetch_weather_information()
 {
 	display_weather=$1
-	# it gets the weather condition textual name (%C), the temperature (%t), and the location (%l)
+	# it gets the weather condition textual name (%C), and the temperature (%t)
 	curl -sL wttr.in\?format="+%C+%t$display_weather"
 }
 

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -35,7 +35,7 @@ display_weather()
 	temperature=$(echo $weather_information | rev | cut -d ' ' -f 1 | rev) # +31°C, -3°F, etc
 	unicode=$(forecast_unicode $weather_condition)
 
-	echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
+	echo "$unicode${temperature/+/}" # remove the plus sign to the temperature
 }
 
 forecast_unicode()

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -18,7 +18,7 @@ fetch_weather_information()
 {
 	display_weather=$1
 	# it gets the weather condition textual name (%C), the temperature (%t), and the location (%l)
-	curl -sL curl wttr.in\?format="+%C+%t$display_weather"
+	curl -sL wttr.in\?format="+%C+%t$display_weather"
 }
 
 #get weather display

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 
-
 fahrenheit=$1
+location=$2
 
-load_request_params()
+display_location()
 {
-	city=$(curl -s https://ipinfo.io/city 2> /dev/null)
-	region=$(curl -s https://ipinfo.io/region 2> /dev/null)
+	if $location; then
+		city=$(curl -s https://ipinfo.io/city 2> /dev/null)
+		region=$(curl -s https://ipinfo.io/region 2> /dev/null)
+		echo " $city, $region"
+	else
+		echo ''
+	fi
 }
-
 
 fetch_weather_information()
 {
 	display_weather=$1
-	# it gets the weather condition textual name (%C), the temperature (%t), and the location (%l) 
+	# it gets the weather condition textual name (%C), the temperature (%t), and the location (%l)
 	curl -sL curl wttr.in\?format="+%C+%t$display_weather"
 }
 
@@ -34,7 +38,7 @@ display_weather()
 	echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
 }
 
-forecast_unicode() 
+forecast_unicode()
 {
 	weather_condition=$(echo $weather_condition | awk '{print tolower($0)}')
 
@@ -53,10 +57,9 @@ forecast_unicode()
 
 main()
 {
-	load_request_params
 	# process should be cancelled when session is killed
 	if ping -q -c 1 -W 1 ipinfo.io &>/dev/null; then
-		echo "$(display_weather) $city, $region"
+		echo "$(display_weather)$(display_location)"
 	else
 		echo "Location Unavailable"
 	fi

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -31,8 +31,8 @@ display_weather()
 	fi
 	weather_information=$(fetch_weather_information $display_weather)
 
-	weather_condition=$(echo $weather_information |  cut -d "+" -f 1 | cut -d "-" -f 1) # Sunny, Snow, etc
-	temperature=$(echo $weather_information | cut -d '+' -f 2) # +31°C, -3°F, etc
+	weather_condition=$(echo $weather_information | rev | cut -d ' ' -f2- | rev) # Sunny, Snow, etc
+	temperature=$(echo $weather_information | rev | cut -d ' ' -f 1 | rev) # +31°C, -3°F, etc
 	unicode=$(forecast_unicode $weather_condition)
 
 	echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature


### PR DESCRIPTION
Hi!
I added an option to show or not the location in the weather by toggling:
set -g @dracula-show-location false in .tmux.conf to hide it (default true)

I also corrected the temperature that was not cut right if it was minus 0 (-2°C).
The cut for weather_condition as been improve so that it takes everything before the temperature.