### PR TITLE
Document location information toggle

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,7 @@ Customize the status bar by adding any of these lines to your .tmux.conf as desi
 * Disable battery functionality: `set -g @dracula-show-battery false`
 * Disable network functionality: `set -g @dracula-show-network false`
 * Disable weather functionality: `set -g @dracula-show-weather false`
+* Disable location information: `set -g @dracula-show-location false`
 * Switch from default fahrenheit to celsius: `set -g @dracula-show-fahrenheit false`
 * Enable powerline symbols: `set -g @dracula-show-powerline true`
 * Switch powerline symbols `set -g @dracula-show-left-sep ` for left and `set -g @dracula-show-right-sep ` for right symbol (can set any symbol you like as seperator)


### PR DESCRIPTION
Add missing documentation location information toggle introduced in https://github.com/dracula/tmux/pull/78