### PR TITLE
change network script to works fine in all Linux flavor OS

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -9,7 +9,7 @@ get_ssid()
 	# Check OS
 	case $(uname -s) in
 		Linux)
-			SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+			SSID=$(nmcli -t -f active,ssid dev wifi | egrep '^yes' | cut -d\' -f2 | sed -e 's/yes://g')
 			if [ -n "$SSID" ]; then
 				printf '%s' "$SSID"
 			else


### PR DESCRIPTION
As in most Linux based OS, `iw` command located in `/sbin` and `/usr/sbin/iw` Normal users cannot access this tool easily, so using the `nmcli` makes this easy to show network in the status panel. 