### PR TITLE
Added padding at the end of left icon for custom args

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,7 @@ Customize the status bar by adding any of these lines to your .tmux.conf as desi
 * Enable military time: `set -g @dracula-military-time true`
 * Disable timezone: `set -g @dracula-show-timezone false`
 * Switch the left smiley icon `set -g @dracula-show-left-icon session` it can accept `session`, `smiley`, `window`, or any character.
+* Add padding to the left smiley icon `set -g @dracula-left-icon-padding` default is 1, it can accept any number and 0 disables padding.
 * Enable high contrast pane border: `set -g @dracula-border-contrast true`
 * Enable cpu usage: `set -g @dracula-cpu-usage true`
 * Enable ram usage: `set -g @dracula-ram-usage true`

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -67,7 +67,10 @@ main()
   esac
 
   # Handle left icon padding
+  padding=""
+  if [ "$show_left_icon_padding" -gt "0" ]; then
   padding="$(seq -f " " -s '' $show_left_icon_padding)"
+  fi
   left_icon="$left_icon$padding"
 
   # Handle powerline option

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -62,7 +62,7 @@ main()
       window)
 	  left_icon="#W ";;
       *)
-          left_icon=$show_left_icon;;
+          left_icon="$show_left_icon ";;
   esac
 
   # Handle powerline option

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -27,6 +27,7 @@ main()
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
+  show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
   show_military=$(get_tmux_option "@dracula-military-time" false)
   show_timezone=$(get_tmux_option "@dracula-show-timezone" true)
   show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
@@ -56,14 +57,18 @@ main()
   # Handle left icon configuration
   case $show_left_icon in
       smiley)
-          left_icon="☺ ";;
+          left_icon="☺";;
       session)
-          left_icon="#S ";;
+          left_icon="#S";;
       window)
-	  left_icon="#W ";;
+          left_icon="#W";;
       *)
-          left_icon="$show_left_icon ";;
+          left_icon=$show_left_icon;;
   esac
+
+  # Handle left icon padding
+  padding="$(seq -f " " -s '' $show_left_icon_padding)"
+  left_icon="$left_icon$padding"
 
   # Handle powerline option
   if $show_powerline; then


### PR DESCRIPTION
When using the `dracula-show-left-icon` option with a custom character, there's missing padding to the right of the character like so

![Screen Shot 2020-11-20 at 18 06 48](https://user-images.githubusercontent.com/25142284/99861280-3966f880-2b5b-11eb-9104-1c6b6358aba9.png)

To fix this, the extra padding was added when assigning the `left_icon` variable