### PR TITLE
Fix: False AC charging message on MacOS

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -67,7 +67,7 @@ battery_status()
 		;;
 
 		Darwin)
-			status=$(pmset -g batt | sed -n 2p | cut -d ';' -f 2)
+			status=$(pmset -g batt | sed -n 2p | cut -d ';' -f 2 | tr -d " ")
 		;;
 
 		FreeBSD)


### PR DESCRIPTION
Minor fix: removed whitespace before comparing output of battery status.

closes #91 