### PR TITLE
Create function to normalize cpu usage width

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -14,12 +14,24 @@ get_tmux_option() {
   fi
 }
 
+# normalize the percentage string to always have a length of 5 
+normalize_percent_len() {
+	# the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
+	max_len=5
+	percent_len=${#1}
+	let diff_len=$max_len-$percent_len
+	# if the diff_len is even, left will have 1 more space than right
+	let left_spaces=($diff_len+1)/2
+	let right_spaces=($diff_len)/2
+	printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
+}
+
 get_percent()
 {
 	case $(uname -s) in
 		Linux)
 			percent=$(LC_NUMERIC=en_US.UTF-8 top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
-			echo $percent
+			normalize_percent_len $percent
 		;;
 		
 		Darwin)
@@ -27,7 +39,7 @@ get_percent()
 			cpucores=$(sysctl -n hw.logicalcpu)
 			cpuusage=$(( cpuvalue / cpucores ))
 			percent="$cpuusage%"
-			echo $percent
+			normalize_percent_len $percent
 		;;
 
 		CYGWIN*|MINGW32*|MSYS*|MINGW*)


### PR DESCRIPTION
__Issue__: Closes #97 

__Description__:
Instead of just echo the usage percent (wich have a variable length), `get_percent()` now pass the percent to a normalizer function to set the percent string length always to 5. By doing this the CPU usage status will have a contant length, always placing its valor in the middle of the box.

__Testing__:
I commented the line that gets the percentage of the system in `cpu_info.sh` and set the percentage manually, started a new tmux session without the plugin and manually sourcered `dracula.tmux`. Then, I changed the percentage value to test all valid lengths (from 2 to "1%" to 5 to "11.1%") and waited for the script's sleep to update the status bar.
Obs.: Tested only in linux (debian 10).