### PR TITLE
Network bandwith feature

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ programs.tmux = {
 Customize the status bar by adding any of these lines to your .tmux.conf as desired:  
 * Disable battery functionality: `set -g @dracula-show-battery false`
 * Disable network functionality: `set -g @dracula-show-network false`
+* Enable network bandwith functionality: `set -g @dracula-network-bandwith $network_name`
+  - You could get the `$network_name` through the command: `sudo lshw -class network -short | grep wl | awk '{print $2}'`
 * Disable weather functionality: `set -g @dracula-show-weather false`
 * Disable time functionality: `set -g @dracula-show-time false`
 * Disable location information: `set -g @dracula-show-location false`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 * Support for powerline
 * Day, date, time, timezone
 * Current location based on network with temperature and forecast icon (if available)
-* Network connection status and SSID
+* Network connection status, bandwith and SSID
 * Battery percentage and AC power connection status
 * Refresh rate control
 * CPU usage

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -113,7 +113,7 @@ main()
 
   # set length
   tmux set-option -g status-left-length 100
-  tmux set-option -g status-right-length 100
+  tmux set-option -g status-right-length 250 
 
   # pane border styling
   if $show_border_contrast; then

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -114,7 +114,7 @@ main()
 
   # set length
   tmux set-option -g status-left-length 100
-  tmux set-option -g status-right-length 250 
+  tmux set-option -g status-right-length 100 
 
   # pane border styling
   if $show_border_contrast; then
@@ -169,6 +169,7 @@ main()
       fi
 
       if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
+        tmux set-option -g status-right-length 250 
         tmux set-option -ga status-right "#[fg=${green},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh)"
         powerbg=${green}
       fi
@@ -218,6 +219,7 @@ main()
       fi
 
       if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
+        tmux set-option -g status-right-length 250 
         tmux set-option -ga status-right "#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh) "
       fi
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -39,6 +39,7 @@ main()
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_time=$(get_tmux_option "@dracula-show-time" true)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
+  show_network_bandwith=$(get_tmux_option "@dracula-network-bandwith" "")
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -167,6 +168,11 @@ main()
         powerbg=${cyan}
       fi
 
+      if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
+        tmux set-option -ga status-right "#[fg=${green},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh)"
+        powerbg=${green}
+      fi
+
       if $show_weather; then # weather
         tmux set-option -ga status-right "#[fg=${orange},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${orange}] #(cat $current_dir/../data/weather.txt)"
         powerbg=${orange}
@@ -209,6 +215,10 @@ main()
 
       if $show_network; then # network
         tmux set-option -ga status-right "#[fg=${dark_gray},bg=${cyan}] #($current_dir/network.sh) "
+      fi
+
+      if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
+        tmux set-option -ga status-right "#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh) "
       fi
 
       if $show_weather; then # weather

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INTERVAL="1"  # update interval in seconds
 

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+INTERVAL="1"  # update interval in seconds
+
+network_name=$(tmux show-option -gqv "@dracula-network-bandwith")
+
+main() {
+  while true
+    do
+      initial_download=`cat /sys/class/net/$network_name/statistics/rx_bytes`
+      initial_upload=`cat /sys/class/net/$network_name/statistics/tx_bytes`
+      
+      sleep $INTERVAL
+      
+      final_download=`cat /sys/class/net/$network_name/statistics/rx_bytes`
+      final_upload=`cat /sys/class/net/$network_name/statistics/tx_bytes`
+
+      total_download_bps=`expr $final_download - $initial_download`
+      total_upload_bps=`expr $final_upload - $initial_upload`
+
+      total_download_kbps=$(echo "scale=2; $total_download_bps / 1024" | bc)
+      total_upload_kbps=$(echo "scale=2; $total_upload_bps / 1024" | bc)
+
+      echo "↑ $total_upload_kbps kB/s • ↓ $total_download_kbps kB/s"
+    done
+}
+main

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -21,7 +21,7 @@ main() {
       total_download_kbps=$(echo "scale=2; $total_download_bps / 1024" | bc)
       total_upload_kbps=$(echo "scale=2; $total_upload_bps / 1024" | bc)
 
-      echo "↑ $total_upload_kbps kB/s • ↓ $total_download_kbps kB/s"
+      echo "↓ $total_download_kbps kB/s • ↑ $total_upload_kbps kB/s"
     done
 }
 main

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -7,16 +7,16 @@ network_name=$(tmux show-option -gqv "@dracula-network-bandwith")
 main() {
   while true
     do
-      initial_download=`cat /sys/class/net/$network_name/statistics/rx_bytes`
-      initial_upload=`cat /sys/class/net/$network_name/statistics/tx_bytes`
+      initial_download=$(cat /sys/class/net/$network_name/statistics/rx_bytes)
+      initial_upload=$(cat /sys/class/net/$network_name/statistics/tx_bytes)
       
       sleep $INTERVAL
       
-      final_download=`cat /sys/class/net/$network_name/statistics/rx_bytes`
-      final_upload=`cat /sys/class/net/$network_name/statistics/tx_bytes`
+      final_download=$(cat /sys/class/net/$network_name/statistics/rx_bytes)
+      final_upload=$(cat /sys/class/net/$network_name/statistics/tx_bytes)
 
-      total_download_bps=`expr $final_download - $initial_download`
-      total_upload_bps=`expr $final_upload - $initial_upload`
+      total_download_bps=$(expr $final_download - $initial_download)
+      total_upload_bps=$(expr $final_upload - $initial_upload)
 
       total_download_kbps=$(echo "scale=2; $total_download_bps / 1024" | bc)
       total_upload_kbps=$(echo "scale=2; $total_upload_bps / 1024" | bc)


### PR DESCRIPTION
## Issue
This feature intend to create a helper to show user network bandwith, without packages dependencies.

## Description of Changes
I Created a network_bandwith.sh file that's the script helper and I've needed increase the status-right-length value because with the default value the status bar was cutting the bars. Also I've added some installation and readme instructions;

## Testing
Tested on: `Linux 5.8.0-48-generic Ubuntu 20.10 x86_64 GNU/Linux`.
Made all the changes on the tpm plugin script and run `./dracula.tmux` to load network bandwith script