### PR TITLE
Customizations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -4,58 +4,58 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-	local option=$1
-	local default_value=$2
-	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z $option_value ]; then
-		echo $default_value
-	else
-		echo $option_value
-	fi
+  local option=$1
+  local default_value=$2
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z $option_value ]; then
+    echo $default_value
+  else
+    echo $option_value
+  fi
 }
 
 # normalize the percentage string to always have a length of 5
 normalize_percent_len() {
-	# the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
-	max_len=5
-	percent_len=${#1}
-	let diff_len=$max_len-$percent_len
-	# if the diff_len is even, left will have 1 more space than right
-	let left_spaces=($diff_len+1)/2
-	let right_spaces=($diff_len)/2
-	printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
+  # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
+  max_len=5
+  percent_len=${#1}
+  let diff_len=$max_len-$percent_len
+  # if the diff_len is even, left will have 1 more space than right
+  let left_spaces=($diff_len+1)/2
+  let right_spaces=($diff_len)/2
+  printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
 }
 
 get_percent()
 {
-	case $(uname -s) in
-		Linux)
-			percent=$(LC_NUMERIC=en_US.UTF-8 top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
-			normalize_percent_len $percent
-			;;
+  case $(uname -s) in
+    Linux)
+      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+      normalize_percent_len $percent
+      ;;
 
-		Darwin)
-			cpuvalue=$(ps -A -o %cpu | awk -F. '{s+=$1} END {print s}')
-			cpucores=$(sysctl -n hw.logicalcpu)
-			cpuusage=$(( cpuvalue / cpucores ))
-			percent="$cpuusage%"
-			normalize_percent_len $percent
-			;;
+    Darwin)
+      cpuvalue=$(ps -A -o %cpu | awk -F. '{s+=$1} END {print s}')
+      cpucores=$(sysctl -n hw.logicalcpu)
+      cpuusage=$(( cpuvalue / cpucores ))
+      percent="$cpuusage%"
+      normalize_percent_len $percent
+      ;;
 
-		CYGWIN*|MINGW32*|MSYS*|MINGW*)
-			# TODO - windows compatability
-			;;
-	esac
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+      # TODO - windows compatability
+      ;;
+  esac
 }
 
 main()
 {
-	# storing the refresh rate in the variable RATE, default is 5
-	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-	cpu_label=$(get_tmux_option "@dracula-cpu-label" "CPU")
-	cpu_percent=$(get_percent)
-	echo "$cpu_label $cpu_percent"
-	sleep $RATE
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  cpu_label=$(get_tmux_option "@dracula-cpu-usage-label" "CPU")
+  cpu_percent=$(get_percent)
+  echo "$cpu_label $cpu_percent"
+  sleep $RATE
 }
 
 # run main driver

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -4,17 +4,17 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-option -gqv "$option")
-  if [ -z $option_value ]; then
-    echo $default_value
-  else
-    echo $option_value
-  fi
+	local option=$1
+	local default_value=$2
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z $option_value ]; then
+		echo $default_value
+	else
+		echo $option_value
+	fi
 }
 
-# normalize the percentage string to always have a length of 5 
+# normalize the percentage string to always have a length of 5
 normalize_percent_len() {
 	# the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
 	max_len=5
@@ -32,19 +32,19 @@ get_percent()
 		Linux)
 			percent=$(LC_NUMERIC=en_US.UTF-8 top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
 			normalize_percent_len $percent
-		;;
-		
+			;;
+
 		Darwin)
 			cpuvalue=$(ps -A -o %cpu | awk -F. '{s+=$1} END {print s}')
 			cpucores=$(sysctl -n hw.logicalcpu)
 			cpuusage=$(( cpuvalue / cpucores ))
 			percent="$cpuusage%"
 			normalize_percent_len $percent
-		;;
+			;;
 
 		CYGWIN*|MINGW32*|MSYS*|MINGW*)
 			# TODO - windows compatability
-		;;
+			;;
 	esac
 }
 
@@ -52,8 +52,9 @@ main()
 {
 	# storing the refresh rate in the variable RATE, default is 5
 	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+	cpu_label=$(get_tmux_option "@dracula-cpu-label" "CPU")
 	cpu_percent=$(get_percent)
-	echo "CPU $cpu_percent"
+	echo "$cpu_label $cpu_percent"
 	sleep $RATE
 }
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -21,9 +21,6 @@ main()
   current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
   # set configuration option variables
-  show_battery=$(get_tmux_option "@dracula-show-battery" true)
-  show_network=$(get_tmux_option "@dracula-show-network" true)
-  show_weather=$(get_tmux_option "@dracula-show-weather" true)
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
   show_location=$(get_tmux_option "@dracula-show-location" true)
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
@@ -35,13 +32,8 @@ main()
   show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
   show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
   show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
-  show_cpu_usage=$(get_tmux_option "@dracula-cpu-usage" false)
-  show_ram_usage=$(get_tmux_option "@dracula-ram-usage" false)
-  show_gpu_usage=$(get_tmux_option "@dracula-gpu-usage" false)
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
-  show_time=$(get_tmux_option "@dracula-show-time" true)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
-  show_network_bandwith=$(get_tmux_option "@dracula-network-bandwith" "")
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -59,27 +51,27 @@ main()
 
   # Handle left icon configuration
   case $show_left_icon in
-      smiley)
-          left_icon="☺";;
-      session)
-          left_icon="#S";;
-      window)
-          left_icon="#W";;
-      *)
-          left_icon=$show_left_icon;;
+    smiley)
+      left_icon="☺";;
+    session)
+      left_icon="#S";;
+    window)
+      left_icon="#W";;
+    *)
+      left_icon=$show_left_icon;;
   esac
 
   # Handle left icon padding
   padding=""
   if [ "$show_left_icon_padding" -gt "0" ]; then
-	  padding="$(printf '%*s' $show_left_icon_padding)"
+    padding="$(printf '%*s' $show_left_icon_padding)"
   fi
   left_icon="$left_icon$padding"
 
   # Handle powerline option
   if $show_powerline; then
-      right_sep="$show_right_sep"
-      left_sep="$show_left_sep"
+    right_sep="$show_right_sep"
+    left_sep="$show_left_sep"
   fi
 
   # start weather script in background
@@ -89,10 +81,10 @@ main()
 
   # Set timezone unless hidden by configuration
   case $show_timezone in
-      false)
-          timezone="";;
-      true)
-          timezone="#(date +%Z)";;
+    false)
+      timezone="";;
+    true)
+      timezone="#(date +%Z)";;
   esac
 
   case $show_flags in
@@ -109,14 +101,14 @@ main()
 
   # set the prefix + t time format
   if $show_military; then
-	tmux set-option -g clock-mode-style 24
+    tmux set-option -g clock-mode-style 24
   else
-	tmux set-option -g clock-mode-style 12
+    tmux set-option -g clock-mode-style 12
   fi
 
   # set length
   tmux set-option -g status-left-length 100
-  tmux set-option -g status-right-length 100 
+  tmux set-option -g status-right-length 100
 
   # pane border styling
   if $show_border_contrast; then
@@ -135,114 +127,87 @@ main()
   # wait unit $datafile exists just to avoid errors
   # this should almost never need to wait unless something unexpected occurs
   while $show_weather && [ ! -f $datafile ]; do
-      sleep 0.01
+    sleep 0.01
   done
 
-  # Powerline Configuration
+
+  # Status left
   if $show_powerline; then
-
-      tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
-      tmux set-option -g  status-right ""
-      powerbg=${gray}
-
-      if $show_battery; then # battery
-        tmux set-option -g  status-right "#[fg=${pink},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${pink}] #($current_dir/battery.sh)"
-        powerbg=${pink}
-      fi
-
-      if $show_ram_usage; then
-	 tmux set-option -ga status-right "#[fg=${cyan},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${cyan}] #($current_dir/ram_info.sh)"
-	 powerbg=${cyan}
-      fi
-
-      if $show_cpu_usage; then
-	 tmux set-option -ga status-right "#[fg=${orange},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${orange}] #($current_dir/cpu_info.sh)"
-	 powerbg=${orange}
-      fi
-
-      if $show_gpu_usage; then
-	 tmux set-option -ga status-right "#[fg=${pink},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${pink}] #($current_dir/gpu_usage.sh)"
-	 powerbg=${pink}
-      fi
-
-      if $show_network; then # network
-        tmux set-option -ga status-right "#[fg=${cyan},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${cyan}] #($current_dir/network.sh)"
-        powerbg=${cyan}
-      fi
-
-      if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
-        tmux set-option -g status-right-length 250 
-        tmux set-option -ga status-right "#[fg=${green},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh)"
-        powerbg=${green}
-      fi
-
-      if $show_weather; then # weather
-        tmux set-option -ga status-right "#[fg=${orange},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${dark_gray},bg=${orange}] #(cat $datafile)"
-        powerbg=${orange}
-      fi
-
-      if $show_time; then
-        if $show_day_month && $show_military ; then # military time and dd/mm
-          tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %d/%m %R ${timezone} "
-        elif $show_military; then # only military time
-          tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
-        elif $show_day_month; then # only dd/mm
-          tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %d/%m %I:%M %p ${timezone} "
-        else
-          tmux set-option -ga status-right "#[fg=${dark_purple},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
-        fi
-      fi
-
-      tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
-
-  # Non Powerline Configuration
+    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
+    powerbg=${gray}
   else
     tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
+  fi
 
-    tmux set-option -g  status-right ""
+  # Status right
+  tmux set-option -g status-right ""
+  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
 
-      if $show_battery; then # battery
-        tmux set-option -g  status-right "#[fg=${dark_gray},bg=${pink}] #($current_dir/battery.sh) "
+  for plugin in "${plugins[@]}"; do
+    if [ $plugin = "battery" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")
+      script="#($current_dir/battery.hs)"
+    fi
+
+    if [ $plugin = "gpu-usage" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-gpu-usage-colors" "pink dark_gray")
+      script="#($current_dir/gpu_usage.sh)"
+    fi
+
+    if [ $plugin = "cpu-usage" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-cpu-usage-colors" "orange dark_gray")
+      script="#($current_dir/cpu_info.sh)"
+    fi
+
+    if [ $plugin = "ram-usage" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-ram-usage-colors" "cyan dark_gray")
+      script="#($current_dir/ram_info.sh)"
+    fi
+
+    if [ $plugin = "network" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-colors" "cyan dark_gray")
+      script="#($current_dir/network.sh)"
+    fi
+
+    if [ $plugin = "network-bandwith" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwith-colors" "cyan dark_gray")
+      tmux set-option -g status-right-length 250
+      script="#($current_dir/network_bandwith.sh)"
+    fi
+
+    if [ $plugin = "weather" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
+      script="#(cat $datafile)"
+    fi
+
+    if [ $plugin = "time" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "dark_purple white")
+      if $show_day_month && $show_military ; then # military time and dd/mm
+        script="%a %d/%m %R ${timezone} "
+      elif $show_military; then # only military time
+        script="%a %m/%d %R ${timezone} "
+      elif $show_day_month; then # only dd/mm
+        script="%a %d/%m %I:%M %p ${timezone} "
+      else
+        script="%a %m/%d %I:%M %p ${timezone} "
       fi
-      if $show_ram_usage; then
-	tmux set-option -ga status-right "#[fg=${dark_gray},bg=${cyan}] #($current_dir/ram_info.sh) "
-      fi
+    fi
 
-      if $show_cpu_usage; then
-	tmux set-option -ga status-right "#[fg=${dark_gray},bg=${orange}] #($current_dir/cpu_info.sh) "
-      fi
+    if $show_powerline; then
+      tmux set-option -ga status-right "#[fg=${!colors[0]},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script"
+      powerbg=${!colors[0]}
+    else
+      tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script"
+    fi
+  done
 
-      if $show_gpu_usage; then
-	tmux set-option -ga status-right "#[fg=${dark_gray},bg=${pink}] #($current_dir/gpu_usage.sh) "
-      fi
+  tmux set-option -ga status-right " "
 
-      if $show_network; then # network
-        tmux set-option -ga status-right "#[fg=${dark_gray},bg=${cyan}] #($current_dir/network.sh) "
-      fi
-
-      if [[ "$show_network_bandwith" != "" ]]; then # network bandwith
-        tmux set-option -g status-right-length 250 
-        tmux set-option -ga status-right "#[fg=${dark_gray},bg=${green}] #($current_dir/network_bandwith.sh) "
-      fi
-
-      if $show_weather; then # weather
-          tmux set-option -ga status-right "#[fg=${dark_gray},bg=${orange}] #(cat $datafile) "
-      fi
-
-      if $show_time; then
-        if $show_day_month && $show_military ; then # military time and dd/mm
-          tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %d/%m %R ${timezone} "
-        elif $show_military; then # only military time
-          tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %R ${timezone} "
-        elif $show_day_month; then # only dd/mm
-          tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %d/%m %I:%M %p ${timezone} "
-        else
-          tmux set-option -ga status-right "#[fg=${white},bg=${dark_purple}] %a %m/%d %I:%M %p ${timezone} "
-        fi
-      fi
-
-      tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
-
+  # Window option
+  if $show_powerline; then
+    tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
+  else
+    tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
   fi
 
   tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W${flags}"

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -4,14 +4,14 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-option -gqv "$option")
-  if [ -z $option_value ]; then
-    echo $default_value
-  else
-    echo $option_value
-  fi
+	local option=$1
+	local default_value=$2
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z $option_value ]; then
+		echo $default_value
+	else
+		echo $option_value
+	fi
 }
 
 get_platform()
@@ -20,34 +20,50 @@ get_platform()
 		Linux)
 			gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
 			echo $gpu
-		;;
+			;;
 
 		Darwin)
 			# TODO - Darwin/Mac compatability
-		;;
+			;;
 
 		CYGWIN*|MINGW32*|MSYS*|MINGW*)
 			# TODO - windows compatability
-		;;
+			;;
 	esac
 }
+
+# normalize the percentage string to always have a length of 5
+normalize_percent_len() {
+	# the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
+	max_len=5
+	percent_len=${#1}
+	let diff_len=$max_len-$percent_len
+	# if the diff_len is even, left will have 1 more space than right
+	let left_spaces=($diff_len+1)/2
+	let right_spaces=($diff_len)/2
+	printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
+}
+
 get_gpu()
 {
 	gpu=$(get_platform)
 	if [[ "$gpu" == NVIDIA ]]; then
-    usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
-  else
-    usage='unknown'
+		usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
+	else
+		usage='unknown'
 	fi
-  echo $usage
+	normalize_percent_len $usage
 }
+
 main()
 {
 	# storing the refresh rate in the variable RATE, default is 5
 	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+	gpu_label=$(get_tmux_option "@dracula-gpu-label" "GPU")
 	gpu_usage=$(get_gpu)
-	echo "GPU $gpu_usage"
+	echo "$gpu_label $gpu_usage"
 	sleep $RATE
 }
+
 # run the main driver
 main

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -4,65 +4,65 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-	local option=$1
-	local default_value=$2
-	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z $option_value ]; then
-		echo $default_value
-	else
-		echo $option_value
-	fi
+  local option=$1
+  local default_value=$2
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z $option_value ]; then
+    echo $default_value
+  else
+    echo $option_value
+  fi
 }
 
 get_platform()
 {
-	case $(uname -s) in
-		Linux)
-			gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-			echo $gpu
-			;;
+  case $(uname -s) in
+    Linux)
+      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+      echo $gpu
+      ;;
 
-		Darwin)
-			# TODO - Darwin/Mac compatability
-			;;
+    Darwin)
+      # TODO - Darwin/Mac compatability
+      ;;
 
-		CYGWIN*|MINGW32*|MSYS*|MINGW*)
-			# TODO - windows compatability
-			;;
-	esac
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+      # TODO - windows compatability
+      ;;
+  esac
 }
 
 # normalize the percentage string to always have a length of 5
 normalize_percent_len() {
-	# the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
-	max_len=5
-	percent_len=${#1}
-	let diff_len=$max_len-$percent_len
-	# if the diff_len is even, left will have 1 more space than right
-	let left_spaces=($diff_len+1)/2
-	let right_spaces=($diff_len)/2
-	printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
+  # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
+  max_len=5
+  percent_len=${#1}
+  let diff_len=$max_len-$percent_len
+  # if the diff_len is even, left will have 1 more space than right
+  let left_spaces=($diff_len+1)/2
+  let right_spaces=($diff_len)/2
+  printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
 }
 
 get_gpu()
 {
-	gpu=$(get_platform)
-	if [[ "$gpu" == NVIDIA ]]; then
-		usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
-	else
-		usage='unknown'
-	fi
-	normalize_percent_len $usage
+  gpu=$(get_platform)
+  if [[ "$gpu" == NVIDIA ]]; then
+    usage=$(nvidia-smi | grep '%' | awk '{ sum += $13 } END { printf("%d%%\n", sum / NR) }')
+  else
+    usage='unknown'
+  fi
+  normalize_percent_len $usage
 }
 
 main()
 {
-	# storing the refresh rate in the variable RATE, default is 5
-	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-	gpu_label=$(get_tmux_option "@dracula-gpu-label" "GPU")
-	gpu_usage=$(get_gpu)
-	echo "$gpu_label $gpu_usage"
-	sleep $RATE
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  gpu_label=$(get_tmux_option "@dracula-gpu-usage-label" "GPU")
+  gpu_usage=$(get_gpu)
+  echo "$gpu_label $gpu_usage"
+  sleep $RATE
 }
 
 # run the main driver

--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -4,14 +4,14 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-option -gqv "$option")
-  if [ -z $option_value ]; then
-    echo $default_value
-  else
-    echo $option_value
-  fi
+	local option=$1
+	local default_value=$2
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z $option_value ]; then
+		echo $default_value
+	else
+		echo $option_value
+	fi
 }
 
 get_percent()
@@ -33,7 +33,7 @@ get_percent()
 				memory_usage=$(free -g | awk '/^Mem/ {print $3}')
 				echo $memory_usage\G\B/$total_mem\G\B
 			fi
-		;;
+			;;
 
 		Darwin)
 			# percent=$(ps -A -o %mem | awk '{mem += $1} END {print mem}')
@@ -46,8 +46,8 @@ get_percent()
 				memory=$(($used_mem/1024))
 				echo $memory\G\B/$total_mem
 			fi
-		;;
-		
+			;;
+
 		FreeBSD)
 			# Looked at the code from neofetch
 			hw_pagesize="$(sysctl -n hw.pagesize)"
@@ -65,11 +65,11 @@ get_percent()
 				memory=$(($used_mem/1024))
 				echo $memory\G\B/$total_mem
 			fi
-		;;
+			;;
 
 		CYGWIN*|MINGW32*|MSYS*|MINGW*)
 			# TODO - windows compatability
-		;;
+			;;
 	esac
 }
 
@@ -77,8 +77,9 @@ main()
 {
 	# storing the refresh rate in the variable RATE, default is 5
 	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+	ram_label=$(get_tmux_option "@dracula-ram-label" "GPU")
 	ram_percent=$(get_percent)
-	echo "RAM $ram_percent"
+	echo "$ram_label $ram_percent"
 	sleep $RATE
 }
 

--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -4,83 +4,83 @@ export LC_ALL=en_US.UTF-8
 
 # function for getting the refresh rate
 get_tmux_option() {
-	local option=$1
-	local default_value=$2
-	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z $option_value ]; then
-		echo $default_value
-	else
-		echo $option_value
-	fi
+  local option=$1
+  local default_value=$2
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z $option_value ]; then
+    echo $default_value
+  else
+    echo $option_value
+  fi
 }
 
 get_percent()
 {
-	case $(uname -s) in
-		Linux)
-			# percent=$(free -m | awk 'NR==2{printf "%.1f%%\n", $3*100/$2}')
-			total_mem_gb=$(free -g | awk '/^Mem/ {print $2}')
-			used_mem=$(free -g | awk '/^Mem/ {print $3}')
-			total_mem=$(free -h | awk '/^Mem/ {print $2}')
-			if (( $total_mem_gb == 0)); then
-				memory_usage=$(free -m | awk '/^Mem/ {print $3}')
-				total_mem_mb=$(free -m | awk '/^Mem/ {print $2}')
-				echo $memory_usage\M\B/$total_mem_mb\M\B
-			elif (( $used_mem == 0 )); then
-				memory_usage=$(free -m | awk '/^Mem/ {print $3}')
-				echo $memory_usage\M\B/$total_mem\G\B
-			else
-				memory_usage=$(free -g | awk '/^Mem/ {print $3}')
-				echo $memory_usage\G\B/$total_mem\G\B
-			fi
-			;;
+  case $(uname -s) in
+    Linux)
+      # percent=$(free -m | awk 'NR==2{printf "%.1f%%\n", $3*100/$2}')
+      total_mem_gb=$(free -g | awk '/^Mem/ {print $2}')
+      used_mem=$(free -g | awk '/^Mem/ {print $3}')
+      total_mem=$(free -h | awk '/^Mem/ {print $2}')
+      if (( $total_mem_gb == 0)); then
+        memory_usage=$(free -m | awk '/^Mem/ {print $3}')
+        total_mem_mb=$(free -m | awk '/^Mem/ {print $2}')
+        echo $memory_usage\M\B/$total_mem_mb\M\B
+      elif (( $used_mem == 0 )); then
+        memory_usage=$(free -m | awk '/^Mem/ {print $3}')
+        echo $memory_usage\M\B/$total_mem_gb\G\B
+      else
+        memory_usage=$(free -g | awk '/^Mem/ {print $3}')
+        echo $memory_usage\G\B/$total_mem_gb\G\B
+      fi
+      ;;
 
-		Darwin)
-			# percent=$(ps -A -o %mem | awk '{mem += $1} END {print mem}')
-			# Get used memory blocks with vm_stat, multiply by 4096 to get size in bytes, then convert to MiB
-			used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk '{printf "%d\n", ($1+$2) * 4096 / 1048576}')
-			total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
-			if (( $used_mem < 1024 )); then
-				echo $used_mem\M\B/$total_mem
-			else
-				memory=$(($used_mem/1024))
-				echo $memory\G\B/$total_mem
-			fi
-			;;
+    Darwin)
+      # percent=$(ps -A -o %mem | awk '{mem += $1} END {print mem}')
+      # Get used memory blocks with vm_stat, multiply by 4096 to get size in bytes, then convert to MiB
+      used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk '{printf "%d\n", ($1+$2) * 4096 / 1048576}')
+      total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
+      if (( $used_mem < 1024 )); then
+        echo $used_mem\M\B/$total_mem
+      else
+        memory=$(($used_mem/1024))
+        echo $memory\G\B/$total_mem
+      fi
+      ;;
 
-		FreeBSD)
-			# Looked at the code from neofetch
-			hw_pagesize="$(sysctl -n hw.pagesize)"
-			mem_inactive="$(($(sysctl -n vm.stats.vm.v_inactive_count) * hw_pagesize))"
-			mem_unused="$(($(sysctl -n vm.stats.vm.v_free_count) * hw_pagesize))"
-			mem_cache="$(($(sysctl -n vm.stats.vm.v_cache_count) * hw_pagesize))"
+    FreeBSD)
+      # Looked at the code from neofetch
+      hw_pagesize="$(sysctl -n hw.pagesize)"
+      mem_inactive="$(($(sysctl -n vm.stats.vm.v_inactive_count) * hw_pagesize))"
+      mem_unused="$(($(sysctl -n vm.stats.vm.v_free_count) * hw_pagesize))"
+      mem_cache="$(($(sysctl -n vm.stats.vm.v_cache_count) * hw_pagesize))"
 
-			free_mem=$(((mem_inactive + mem_unused + mem_cache) / 1024 / 1024))
-			total_mem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
-			used_mem=$((total_mem - free_mem))
-			echo $used_mem
-			if (( $used_mem < 1024 )); then
-				echo $used_mem\M\B/$total_mem
-			else
-				memory=$(($used_mem/1024))
-				echo $memory\G\B/$total_mem
-			fi
-			;;
+      free_mem=$(((mem_inactive + mem_unused + mem_cache) / 1024 / 1024))
+      total_mem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
+      used_mem=$((total_mem - free_mem))
+      echo $used_mem
+      if (( $used_mem < 1024 )); then
+        echo $used_mem\M\B/$total_mem
+      else
+        memory=$(($used_mem/1024))
+        echo $memory\G\B/$total_mem
+      fi
+      ;;
 
-		CYGWIN*|MINGW32*|MSYS*|MINGW*)
-			# TODO - windows compatability
-			;;
-	esac
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+      # TODO - windows compatability
+      ;;
+  esac
 }
 
 main()
 {
-	# storing the refresh rate in the variable RATE, default is 5
-	RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-	ram_label=$(get_tmux_option "@dracula-ram-label" "GPU")
-	ram_percent=$(get_percent)
-	echo "$ram_label $ram_percent"
-	sleep $RATE
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  ram_label=$(get_tmux_option "@dracula-ram-usage-label" "GPU")
+  ram_percent=$(get_percent)
+  echo "$ram_label $ram_percent"
+  sleep $RATE
 }
 
 #run main driver


### PR DESCRIPTION
**Changes**

- Plugin order and customization #42 
- Custom label for cpu_info, gpu_usage and ram_info
- Normalize gpu_usage len
- Fix indentation in files
- Fix bug in ram usage #106

**Config**
```conf
set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"

set -g @dracula-ram-usage-label ﬙
set -g @dracula-ram-usage-colors "dark_gray white"

set -g @dracula-gpu-usage-label 
set -g @dracula-gpu-usage-colors "dark_gray white"

set -g @dracula-cpu-usage-label 
set -g @dracula-cpu-usage-colors "dark_gray white"
```

**Normal**
![tmux-normal](https://user-images.githubusercontent.com/22490354/124354346-d4ed3b00-dc0b-11eb-963d-424689f3da98.png)

**Powerline**
![tmux-powershell](https://user-images.githubusercontent.com/22490354/124354353-d9b1ef00-dc0b-11eb-97b0-7fce9780a537.png)

