### PR TITLE
Fix right status spacing

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -187,14 +187,12 @@ main()
     fi
 
     if $show_powerline; then
-      tmux set-option -ga status-right "#[fg=${!colors[0]},bg=${powerbg},nobold,nounderscore,noitalics] ${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script"
+      tmux set-option -ga status-right "#[fg=${!colors[0]},bg=${powerbg},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script "
       powerbg=${!colors[0]}
     else
-      tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script"
+      tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script "
     fi
   done
-  
-  tmux set-option -ga status-right " "
 
   # Window option
   if $show_powerline; then
@@ -210,4 +208,3 @@ main()
 
 # run main function
 main
-


### PR DESCRIPTION
Hallow all !

Only the most right status element seemed to be padded with a space, for
the non-powerline configuration. The powerline configuration seems to alright 
because the padding is embedded along with the the separator.

This commit moves the padding next to the separator to the script
output instead.