### PR TITLE
Add support for displaying network bandwidth usage in macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, gpu-usage, ram-usage, network, network-bandwith, weather, time
+# available plugins: battery, cpu-usage, gpu-usage, ram-usage, network, network-bandwidth, weather, time
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 * Support for powerline
 * Day, date, time, timezone
 * Current location based on network with temperature and forecast icon (if available)
-* Network connection status, bandwith and SSID
+* Network connection status, bandwidth and SSID
 * Battery percentage and AC power connection status
 * Refresh rate control
 * CPU usage

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -125,6 +125,19 @@ main()
   # Status right
   tmux set-option -g status-right ""
 
+  # deprecated status right options (note spelling)
+  dep_bandwith_colors=$(get_tmux_option "@dracula-network-bandwith-colors")
+  if [ -n "$dep_bandwith_colors" ]; then
+    tmux set-option -g -o "@dracula-network-bandwidth-colors" "$dep_bandwith_colors"
+    tmux set-option -u "@dracula-network-bandwith-colors" 
+  fi
+
+  dep_bandwith=$(get_tmux_option "@dracula-network-bandwith")
+  if [ -n "$dep_bandwith" ]; then
+    tmux set-option -g -o "@dracula-network-bandwidth" "$dep_bandwith"
+    tmux set-option -u "@dracula-network-bandwith"
+  fi
+
   for plugin in "${plugins[@]}"; do
     if [ $plugin = "battery" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")
@@ -152,9 +165,13 @@ main()
     fi
 
     if [ $plugin = "network-bandwith" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwith-colors" "cyan dark_gray")
+      plugin="network-bandwidth"
+    fi
+
+    if [ $plugin = "network-bandwidth" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwidth-colors" "cyan dark_gray")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/network_bandwith.sh)"
+      script="#($current_dir/network_bandwidth.sh)"
     fi
 
     if [ $plugin = "weather" ]; then

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -2,7 +2,7 @@
 
 INTERVAL="1"  # update interval in seconds
 
-network_name=$(tmux show-option -gqv "@dracula-network-bandwith")
+network_name=$(tmux show-option -gqv "@dracula-network-bandwidth")
 
 download_bytes() {
   case $(uname -s) in

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -46,8 +46,8 @@ main() {
     total_download_bps=$(expr $final_download - $initial_download)
     total_upload_bps=$(expr $final_upload - $initial_upload)
 
-    total_download_kbps=$(echo "scale=2; $total_download_bps / 1024" | bc)
-    total_upload_kbps=$(echo "scale=2; $total_upload_bps / 1024" | bc)
+    total_download_kbps=$(echo "scale=0; $total_download_bps / 1024" | bc)
+    total_upload_kbps=$(echo "scale=0; $total_upload_bps / 1024" | bc)
 
     echo "↓ $total_download_kbps kB/s • ↑ $total_upload_kbps kB/s"
   done

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -33,8 +33,12 @@ upload_bytes() {
 }
 
 main() {
+  total_download_kbps=0
+  total_upload_kbps=0
   while true
   do
+    echo "$(printf "%8skB/s • %8skB/s" "↓$total_download_kbps" "↑$total_upload_kbps")"
+
     initial_download=$(download_bytes)
     initial_upload=$(upload_bytes)
 
@@ -49,7 +53,6 @@ main() {
     total_download_kbps=$(echo "scale=0; $total_download_bps / 1024" | bc)
     total_upload_kbps=$(echo "scale=0; $total_upload_bps / 1024" | bc)
 
-    echo "$(printf "%8skB/s • %8skB/s" "↓$total_download_kbps" "↑$total_upload_kbps")"
   done
 }
 main

--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -49,7 +49,7 @@ main() {
     total_download_kbps=$(echo "scale=0; $total_download_bps / 1024" | bc)
     total_upload_kbps=$(echo "scale=0; $total_upload_bps / 1024" | bc)
 
-    echo "↓ $total_download_kbps kB/s • ↑ $total_upload_kbps kB/s"
+    echo "$(printf "%8skB/s • %8skB/s" "↓$total_download_kbps" "↑$total_upload_kbps")"
   done
 }
 main


### PR DESCRIPTION
## Description of Changes

Major change is added support for displaying network bandwidth usage when running in macOS

While I was working on it, spotted a couple of other things to fix up
- round kB/s output to only whole numbers (constant updates to the value are annoying when it's a only a few bytes each way)
- set fixed size for displayed output width using `printf` so status bar didn't bounce around as the download/upload values changed
- spelling error the whole way through calling it "network-**bandwith**" instead of "network-**bandwidth**". Fixed that up, however, that requires renaming option names - so kept support for old options, and rewrite them to new corrected options at startup. Tried to display a message about this at startup, but `tmux display-message` doesn't do anything until a session is actually up and running.

## Testing
Have run this on macOS, and works fine, however haven't been able to test on Linux. It _should_ be ok as the only Linux specific code is kept the same.

Pic of plugin running on macOS
![network_bandwidth](https://user-images.githubusercontent.com/27223/126952345-555f9a91-9522-4b95-b04d-27988cd6bf0d.gif)
