### PR TITLE
Fix incorrect color option being read for the time module

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -169,7 +169,7 @@ main()
     fi
 
     if [ $plugin = "time" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "dark_purple white")
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-time-colors" "dark_purple white")
       if $show_day_month && $show_military ; then # military time and dd/mm
         script="%a %d/%m %R ${timezone} "
       elif $show_military; then # only military time


### PR DESCRIPTION
Hi there,

Currently, both the weather and time modules take their color configuration from the `@dracula-weather-colors` option, causing the time module to always look like the weather module :)