### PR TITLE
Fix $used_mem when page size is not 4Kb

### DIFF
--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -37,8 +37,8 @@ get_percent()
 
     Darwin)
       # percent=$(ps -A -o %mem | awk '{mem += $1} END {print mem}')
-      # Get used memory blocks with vm_stat, multiply by 4096 to get size in bytes, then convert to MiB
-      used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk '{printf "%d\n", ($1+$2) * 4096 / 1048576}')
+      # Get used memory blocks with vm_stat, multiply by page size to get size in bytes, then convert to MiB
+      used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2) * pagesize / 1048576}')
       total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
       if (( $used_mem < 1024 )); then
         echo $used_mem\M\B/$total_mem


### PR DESCRIPTION
Page size on M1 Macs is 16k, this PR updates ram_info script to dynamically fetch the page size.

Let me know if you need me to update this PR, wasn't sure how to contribute.