### PR TITLE
Add battery selection for Linux

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=en_US.UTF-8
+export SELECTED_BATTERY="$1"
 
 linux_acpi() {
   arg=$1
-  BAT=$(ls -d /sys/class/power_supply/BAT* | head -1)
+  BAT=$(ls -d "/sys/class/power_supply/BAT$SELECTED_BATTERY" | head -1)
   if [ ! -x "$(which acpi 2> /dev/null)" ];then
     case "$arg" in
       status)
@@ -21,10 +22,10 @@ linux_acpi() {
   else
     case "$arg" in
       status)
-        acpi | cut -d: -f2- | cut -d, -f1 | tr -d ' '
+        acpi | grep "Battery $SELECTED_BATTERY" | cut -d: -f2- | cut -d, -f1 | tr -d ' '
         ;;
       percent)
-        acpi | cut -d: -f2- | cut -d, -f2 | tr -d '% '
+        acpi | grep "Battery $SELECTED_BATTERY" | cut -d: -f2- | cut -d, -f2 | tr -d '% '
         ;;
       *)
         ;;

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -23,6 +23,7 @@ main()
   show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
+  selected_battery=$(get_tmux_option "@dracula-battery" 0)
   IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
 
   # Dracula Color Pallette
@@ -133,7 +134,7 @@ main()
 
     if [ $plugin = "battery" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")
-      script="#($current_dir/battery.sh)"
+      script="#($current_dir/battery.sh $selected_battery)"
     fi
 
     if [ $plugin = "gpu-usage" ]; then


### PR DESCRIPTION
This patch makes it so the user can select which battery they want to display if they have multiple using the `@dracula-battery` option. It also makes the status line always display battery 0 by default if there are multiple, instead of choosing randomly.