### PR TITLE
Fix typos in network_bandwith -> network_bandwidth

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, gpu-usage, ram-usage, network, network-bandwith, weather, time
+# available plugins: battery, cpu-usage, gpu-usage, ram-usage, network, network-bandwidth, weather, time
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 * Support for powerline
 * Day, date, time, timezone
 * Current location based on network with temperature and forecast icon (if available)
-* Network connection status, bandwith and SSID
+* Network connection status, bandwidth and SSID
 * Git branch and status
 * Battery percentage and AC power connection status
 * Refresh rate control

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -156,10 +156,10 @@ main()
       script="#($current_dir/network.sh)"
     fi
 
-    if [ $plugin = "network-bandwith" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwith-colors" "cyan dark_gray")
+    if [ $plugin = "network-bandwidth" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwidth-colors" "cyan dark_gray")
       tmux set-option -g status-right-length 250
-      script="#($current_dir/network_bandwith.sh)"
+      script="#($current_dir/network_bandwidth.sh)"
     fi
 
     if [ $plugin = "weather" ]; then

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -2,7 +2,7 @@
 
 INTERVAL="1"  # update interval in seconds
 
-network_name=$(tmux show-option -gqv "@dracula-network-bandwith")
+network_name=$(tmux show-option -gqv "@dracula-network-bandwidth")
 
 main() {
   while true


### PR DESCRIPTION
Took me a while to figure out why I wasn't getting anything until I spotted the typo on the docs website. This commit fixes the typo of "bandwith" to "bandwidth".