### PR TITLE
Enhancement: Network Bandwidth display format

### DIFF
--- a/scripts/network_bandwith.sh
+++ b/scripts/network_bandwith.sh
@@ -18,8 +18,8 @@ main() {
     total_download_bps=$(expr $final_download - $initial_download)
     total_upload_bps=$(expr $final_upload - $initial_upload)
 
-    total_download_kbps=$(echo "scale=2; $total_download_bps / 1024" | bc)
-    total_upload_kbps=$(echo "scale=2; $total_upload_bps / 1024" | bc)
+    total_download_kbps=$(echo "$total_download_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
+    total_upload_kbps=$(echo "$total_upload_bps 1024" | awk '{printf "%.2f \n", $1/$2}')
 
     echo "↓ $total_download_kbps kB/s • ↑ $total_upload_kbps kB/s"
   done


### PR DESCRIPTION
This Pull Request:

* [x] Adds a leading 0. on network bandwidth values when values are < 0
* [x] Make use of `awk` instead of `bc`  

____

Previous values display:
<img width="232" alt="Screenshot 2021-09-22 at 16 57 37" src="https://user-images.githubusercontent.com/2145612/134368382-bbcd3fa3-a21b-4e0e-a745-acc861fb3c98.png">

New values display:
<img width="263" alt="Screenshot 2021-09-22 at 16 44 22" src="https://user-images.githubusercontent.com/2145612/134367763-8bbb9b8c-1a3d-472f-9d71-c15c3c6e7200.png">


