### PR TITLE
Fix extra padding for time/date feature

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -73,7 +73,7 @@ main()
     false)
       timezone="";;
     true)
-      timezone="#(date +%Z)";;
+      timezone=" #(date +%Z)";;
   esac
 
   case $show_flags in
@@ -176,13 +176,13 @@ main()
     if [ $plugin = "time" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-time-colors" "dark_purple white")
       if $show_day_month && $show_military ; then # military time and dd/mm
-        script="%a %d/%m %R ${timezone} "
+        script="%a %d/%m %R${timezone}"
       elif $show_military; then # only military time
-        script="%a %m/%d %R ${timezone} "
+        script="%a %m/%d %R${timezone}"
       elif $show_day_month; then # only dd/mm
-        script="%a %d/%m %I:%M %p ${timezone} "
+        script="%a %d/%m %I:%M %p${timezone}"
       else
-        script="%a %m/%d %I:%M %p ${timezone} "
+        script="%a %m/%d %I:%M %p${timezone}"
       fi
     fi
 


### PR DESCRIPTION
The time/date "plugin" seems to have an excess amount of padding on the end compared to the opposite side of the bar.

Here's some examples in various configurations before my patch:
![Screenshot_20211010_023220](https://user-images.githubusercontent.com/4153572/136678439-ad9ecf1f-0619-4a8f-a037-0a227f8ddc6a.png)
![Screenshot_20211010_023239](https://user-images.githubusercontent.com/4153572/136678440-1bf0c717-d75f-4445-ade9-5492608b7722.png)
![Screenshot_20211010_023253](https://user-images.githubusercontent.com/4153572/136678441-b61d5668-f4a1-4591-9727-13c702b22699.png)

And here are the same configurations afterwards:
![Screenshot_20211010_023120](https://user-images.githubusercontent.com/4153572/136678427-93e1ac8b-d25e-460c-a5dd-a00220eb0e72.png)
![Screenshot_20211010_023131](https://user-images.githubusercontent.com/4153572/136678428-caa089d6-5db5-444b-b16b-a3ac57b79b77.png)
![Screenshot_20211010_023144](https://user-images.githubusercontent.com/4153572/136678430-68454d78-46c4-4ce4-b025-88c64a46263c.png)

Doesn't seem to cause any issues in my testing.

