### PR TITLE
Enable custom location for weather plugin

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -12,6 +12,7 @@ main()
   # set configuration option variables
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
   show_location=$(get_tmux_option "@dracula-show-location" true)
+  fixed_location=$(get_tmux_option "@dracula-fixed-location")
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
@@ -65,7 +66,7 @@ main()
 
   # start weather script in background
   if [[ "${plugins[@]}" =~ "weather" ]]; then
-    $current_dir/sleep_weather.sh $show_fahrenheit $show_location &
+    $current_dir/sleep_weather.sh $show_fahrenheit $show_location $fixed_location &
   fi
 
   # Set timezone unless hidden by configuration

--- a/scripts/sleep_weather.sh
+++ b/scripts/sleep_weather.sh
@@ -6,6 +6,7 @@ export LC_ALL=en_US.UTF-8
 
 fahrenheit=$1
 location=$2
+fixedlocation=$3
 
 LOCKFILE=/tmp/.dracula-tmux-weather.lock
 DATAFILE=/tmp/.dracula-tmux-data
@@ -31,7 +32,7 @@ main()
 
   while tmux has-session &> /dev/null
   do
-    $current_dir/weather.sh $fahrenheit $location > $DATAFILE
+    $current_dir/weather.sh $fahrenheit $location $fixedlocation > $DATAFILE
     if tmux has-session &> /dev/null
     then
       sleep 1200

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -4,10 +4,13 @@ export LC_ALL=en_US.UTF-8
 
 fahrenheit=$1
 location=$2
+fixedlocation=$3
 
 display_location()
 {
-  if $location; then
+  if $location && [[ ! -z "$fixedlocation" ]]; then
+    echo " $fixedlocation"
+  elif $location; then
     city=$(curl -s https://ipinfo.io/city 2> /dev/null)
     region=$(curl -s https://ipinfo.io/region 2> /dev/null)
     echo " $city, $region"
@@ -20,7 +23,7 @@ fetch_weather_information()
 {
   display_weather=$1
   # it gets the weather condition textual name (%C), and the temperature (%t)
-  curl -sL wttr.in\?format="%C+%t$display_weather"
+  curl -sL wttr.in/$fixedlocation\?format="%C+%t$display_weather"
 }
 
 #get weather display


### PR DESCRIPTION
I think I am not alone who is using VPN for their work and weather plugin is showing the location from ipinfo.io, which in case of using VPN gives wrong location.

PR adds support for custom location, just enter your city. You can verify data on http://wttr.in/YOURTOWN

In tmux.conf add:

`set -g @dracula-fixed-location 'Štúrovo'`

PR also resolves issue #34