### PR TITLE
Add load average support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -119,11 +119,14 @@ Customize label
 set -g @dracula-cpu-usage-label "CPU"
 ```
 
-Show load average instead of percentage
+Show system load average instead of CPU usage percentage (default)
 
 ```bash
 set -g @dracula-cpu-display-load true
 ```
+
+CPU usage percentage (default) - in percentage (output: %)
+Load average – is the average system load calculated over a given period of time of 1, 5 and 15 minutes (output: x.x x.x x.x)
 
 #### gpu-usage options
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -119,6 +119,12 @@ Customize label
 set -g @dracula-cpu-usage-label "CPU"
 ```
 
+Show load average instead of percentage
+
+```bash
+set -g @dracula-cpu-display-load true
+```
+
 #### gpu-usage options
 
 Customize label

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 * Git branch and status
 * Battery percentage and AC power connection status
 * Refresh rate control
-* CPU usage
+* CPU usage (percentage or load average)
 * RAM usage
 * GPU usage
 * Color code based on if prefix is active or not

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -27,13 +27,30 @@ get_percent()
   esac
 }
 
-main()
-{
+get_load() {
+  case $(uname -s) in
+  Linux | Darwin)
+    loadavg=$(uptime | awk -F'[a-z]:' '{ print $2}' | sed 's/,//g')
+    echo $loadavg
+    ;;
+
+  CYGWIN* | MINGW32* | MSYS* | MINGW*)
+    # TODO - windows compatability
+    ;;
+  esac
+}
+
+main() {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-  cpu_label=$(get_tmux_option "@dracula-cpu-usage-label" "CPU")
-  cpu_percent=$(get_percent)
-  echo "$cpu_label $cpu_percent"
+  cpu_load=$(get_tmux_option "@dracula-cpu-display-load" false)
+  if [ "$cpu_load" = true ]; then
+    echo "$(get_load)"
+  else
+    cpu_label=$(get_tmux_option "@dracula-cpu-usage-label" "CPU")
+    cpu_percent=$(get_percent)
+    echo "$cpu_label $cpu_percent"
+  fi
   sleep $RATE
 }
 


### PR DESCRIPTION
This PR adds support for load average to CPU info script.

<img width="1280" alt="Screenshot 2021-12-22 at 23 15 23" src="https://user-images.githubusercontent.com/733361/147161193-07c4968e-6a1c-45e9-8a4e-647fee0459a0.png">

Also resolves request #118 