### PR TITLE
Added kubernetes-context plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 * When prefix is enabled smiley face turns from green to yellow
 * When charging, 'AC' is displayed
 * If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
+* Current kubernetes context
 
 ## Compatibility
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -24,6 +24,7 @@ main()
   show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
+  show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
   IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
 
   # Dracula Color Pallette
@@ -166,6 +167,11 @@ main()
     if [ $plugin = "network-ping" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-network-ping-colors" "cyan dark_gray")
       script="#($current_dir/network_ping.sh)"
+    fi
+
+    if [ $plugin = "kubernetes-context" ]; then
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")
+      script="#($current_dir/kubernetes_context.sh $show_kubernetes_context_label)"
     fi
 
     if [ $plugin = "weather" ]; then

--- a/scripts/kubernetes_context.sh
+++ b/scripts/kubernetes_context.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+label=$1
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+current_context=$(kubectl config view --minify --output 'jsonpath={.current-context}'; echo)
+current_user=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.user}'; echo)
+current_cluster=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.cluster}'; echo)
+current_namespace=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.namespace}'; echo)
+
+main()
+{
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  OUTPUT_STRING=""
+  if [ ! -z "$current_user" ]
+  then
+    OUTPUT_STRING="${current_user}@"
+  fi
+
+  if [ ! -z "$current_cluster" ]
+  then
+    OUTPUT_STRING="${OUTPUT_STRING}${current_cluster}"
+  fi
+
+  if [ ! -z "$current_namespace" ]
+  then
+    OUTPUT_STRING="${OUTPUT_STRING}:${current_namespace}"
+  fi
+
+  if [ "$OUTPUT_STRING" = "" ]
+  then
+    OUTPUT_STRING="kubeconfig not valid"
+  fi
+
+  if [ "$label" = "" ]
+  then
+    echo "${OUTPUT_STRING}"
+  else
+    echo "${label} ${OUTPUT_STRING}"
+  fi
+
+  sleep $RATE
+}
+
+# run the main driver
+main


### PR DESCRIPTION
This pull request is adding a plugin for kubernetes. It shows the current kubernetes status in the statusbar. It needs the tool kubectl installed. 

![image](https://user-images.githubusercontent.com/33316737/153622687-4a4eccd2-a968-4599-a084-487b02fc3053.png)


With the variable dracula-kubernetes-context-label the user can add a prefix for the statusbar entry.
![image](https://user-images.githubusercontent.com/33316737/153622297-7d6d086d-a5a8-4a08-ba9f-faefffe32a6a.png)