### PR TITLE
import utils.sh in battery.sh

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,6 +128,14 @@ set -g @dracula-cpu-display-load true
 CPU usage percentage (default) - in percentage (output: %)
 Load average – is the average system load calculated over a given period of time of 1, 5 and 15 minutes (output: x.x x.x x.x)
 
+#### battery options
+
+Customize label
+
+```bash
+set -g @dracula-battery-label "Battery"
+```
+
 #### gpu-usage options
 
 Customize label

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -2,6 +2,9 @@
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=en_US.UTF-8
 
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
 linux_acpi() {
   arg=$1
   BAT=$(ls -d /sys/class/power_supply/BAT* | head -1)


### PR DESCRIPTION
a utils.sh import is missing in battery.sh causing the @dracula-battery-label option to not work