### PR TITLE
Fix: Battery Status for Fedora 36

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -89,10 +89,10 @@ battery_status()
     discharging|Discharging)
       echo ''
       ;;
-    high)
+    high|Full)
       echo ''
       ;;
-    charging)
+    charging|Charging)
       echo 'AC'
       ;;
     *)


### PR DESCRIPTION
On Fedora the battery status only match with `Discharging`. 