### PR TITLE
Display CPU label on CPU load configuration

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -44,10 +44,10 @@ main() {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   cpu_load=$(get_tmux_option "@dracula-cpu-display-load" false)
+  cpu_label=$(get_tmux_option "@dracula-cpu-usage-label" "CPU")
   if [ "$cpu_load" = true ]; then
-    echo "$(get_load)"
+    echo "$cpu_label $(get_load)"
   else
-    cpu_label=$(get_tmux_option "@dracula-cpu-usage-label" "CPU")
     cpu_percent=$(get_percent)
     echo "$cpu_label $cpu_percent"
   fi


### PR DESCRIPTION
Change to display the defined "dracula-cpu-usage-label" value (e.g. CPU) when load average instead percentage.
Currently the lable is not displayed if CPU load average is 