### PR TITLE
git: add remote info support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -212,6 +212,12 @@ Hide untracked files from being displayed as local changes
 set -g @dracula-git-no-untracked-files true
 ```
 
+Show remote tracking branch together with diverge/sync state
+```bash
+# default is false
+set -g @dracula-git-show-remote-status true
+```
+
 #### weather options
 
 Switch from default fahrenheit to celsius

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -129,7 +129,8 @@ main()
 
     if [ $plugin = "git" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-git-colors" "green dark_gray")
-        script="#($current_dir/git.sh)"     
+      tmux set-option -g status-right-length 250
+      script="#($current_dir/git.sh)"
     fi
 
     if [ $plugin = "battery" ]; then


### PR DESCRIPTION
With this new option, we get information about which remote branch we're tracking. On top of this, we'll get information about ahead/behind commits when we diverged from remote. The output format will be in the form:

'local...remote +ahead -behind',

where ahead and behind are the number of commits ahead and behind.

This functionality is controlled by a new option called '@dracula-git-show-remote-status'.

Note that for this to be properly displayed, we need to increase the size of the right status bar when the git plugin is enabled.

In order to be easier to introduce the change, getMessage() was also a bit changed in order to be easier to append the remote info.

This is how this looks like:

![image](https://user-images.githubusercontent.com/28741857/197984432-410fce1d-77a2-4844-9a70-abe2ff37d790.png)
