### PR TITLE
Add option to show/hide plugins with empty output

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -25,6 +25,7 @@ main()
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
   IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
+  show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
 
   # Dracula Color Pallette
   white='#f8f8f2'
@@ -193,10 +194,18 @@ main()
     fi
 
     if $show_powerline; then
-      tmux set-option -ga status-right "#[fg=${!colors[0]},bg=${powerbg},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script "
+      if $show_empty_plugins; then
+        tmux set-option -ga status-right "#[fg=${!colors[0]},bg=${powerbg},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script "
+      else
+        tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[0]},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script }"
+      fi
       powerbg=${!colors[0]}
     else
-      tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script "
+      if $show_empty_plugins; then
+        tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script "
+      else
+        tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[1]},bg=${!colors[0]}] $script }"
+      fi
     fi
   done
 


### PR DESCRIPTION
This PR adds the option to hide any plugin with an empty output. This allows the creation of alert plugins that are hidden in most cases.

Examples:
- #161 with and without additional clients attached:
  <img width="480" alt="image" src="https://user-images.githubusercontent.com/7785912/198513293-54e6b66e-1573-4db1-8d28-523deff28a38.png">
  <img width="480" alt="image" src="https://user-images.githubusercontent.com/7785912/198513193-19255349-2c99-43bf-8096-14688678dd97.png">
  Before this PR with no clients:
  <img width="480" alt="image" src="https://user-images.githubusercontent.com/7785912/198514464-1d69abdc-1f2b-4543-9c75-d55c4a87c86f.png">

- The battery percent could be configured to show only under a certain percentage, and the CPU and RAM could optionally be hidden under a certain threshold
