### PR TITLE
fix(dracula.sh): fix execution errors

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -172,6 +172,7 @@ main()
     if [ $plugin = "spotify-tui" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")
       script="#($current_dir/spotify-tui.sh)"
+    fi
 
     if [ $plugin = "kubernetes-context" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")


### PR DESCRIPTION
Resolves an issue cause by a syntax error and a removed executable bit introduced by dracula/tmux#153.

The syntax/permissions issue stops the plugin from running properly when I ran into the issue earlier today.

The missing executable bit is likely what's causing dracula/tmux#178. It basically implements the fix @ramaskez [suggested](https://github.com/dracula/tmux/issues/178#issuecomment-1305988132).