### PR TITLE
fix: exclude available RAM from total RAM usage

### DIFF
--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -10,17 +10,17 @@ get_percent()
   case $(uname -s) in
     Linux)
       total_mem_gb=$(free -g | awk '/^Mem/ {print $2}')
-      used_mem=$(free -g | awk '/^Mem/ {print $3}')
+      used_mem=$(free -g | awk '/^Mem/ {print $3 - $7}')
       total_mem=$(free -h | awk '/^Mem/ {print $2}')
       if (( $total_mem_gb == 0)); then
-        memory_usage=$(free -m | awk '/^Mem/ {print $3}')
+        memory_usage=$(free -m | awk '/^Mem/ {print $3 - $7}')
         total_mem_mb=$(free -m | awk '/^Mem/ {print $2}')
         echo $memory_usage\M\B/$total_mem_mb\M\B
       elif (( $used_mem == 0 )); then
-        memory_usage=$(free -m | awk '/^Mem/ {print $3}')
+        memory_usage=$(free -m | awk '/^Mem/ {print $3 - $7}')
         echo $memory_usage\M\B/$total_mem_gb\G\B
       else
-        memory_usage=$(free -g | awk '/^Mem/ {print $3}')
+        memory_usage=$(free -g | awk '/^Mem/ {print $3 - $7}')
         echo $memory_usage\G\B/$total_mem_gb\G\B
       fi
       ;;


### PR DESCRIPTION
The "available" column includes memory that can be made available to the system if needed but is considered as used.

See: https://www.linuxatemyram.com

This fixes #183