### PR TITLE
Add cwd.sh to display the tmux pane's current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
 - Spotify playback (needs the tool spotify-tui installed)
 - Current kubernetes context
+- Current working directory of tmux pane
 
 ## Compatibility
 

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# return current working directory of tmux pane
+getPaneDir()
+{
+  nextone="false"
+  for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
+  do
+    if [ "$nextone" == "true" ]; then
+      echo $i
+      return
+    fi 
+    if [ "$i" == "1" ]; then
+      nextone="true"
+    fi
+  done
+}
+
+main()
+{
+  path=$(getPaneDir)
+
+  # change '/home/user' to '~'
+  cwd=$(echo $path | sed "s;$HOME;~;g")
+
+  echo $cwd
+}
+
+#run main driver program
+main

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -128,6 +128,12 @@ main()
 
   for plugin in "${plugins[@]}"; do
 
+    if [ $plugin = "cwd" ]; then
+      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")
+      tmux set-option -g status-right-length 250
+      script="#($current_dir/cwd.sh)"
+    fi
+
     if [ $plugin = "git" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-git-colors" "green dark_gray")
       tmux set-option -g status-right-length 250


### PR DESCRIPTION
## Issue

Please reference the issue that this PR is solving
Closes #194

## Description of Changes

- Add cwd.sh in scripts, this script references pane_current_path to display the cwd of tmux pane. I set chmod 775 to match the other files in scripts directory
- Add the corresponding 'if block' in dracula.sh for initializing the script
- Update README to reflect the new change, last item in the list of features

## Testing

- Apply plugin
- cd to various directories including root and ensure proper update
- If failure ensure ```set -s escape-time 0``` is set so that tmux will update repeatedly
