### PR TITLE
add network public ip plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, network, network-bandwidth, network-ping, network-public-ip, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context
 
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - Support for powerline
 - Day, date, time, timezone
 - Current location based on network with temperature and forecast icon (if available)
-- Network connection status, bandwidth and SSID
+- Network connection status, bandwidth, SSID and public IP (requires `curl`)
 - Git branch and status
 - Battery percentage and AC power connection status
 - Refresh rate control

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -217,6 +217,10 @@ main()
         fi
       fi
 
+    elif [ $plugin = "network-public-ip" ]; then
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-network-public-ip-colors" "cyan dark_gray")
+      script="#($current_dir/network-public-ip.sh)"
+
     else
       continue
     fi

--- a/scripts/network-public-ip.sh
+++ b/scripts/network-public-ip.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+main() {
+  IP_SERVER="ifconfig.me"
+  ip=$(curl -s "$IP_SERVER")
+
+  IP_LABEL=$(get_tmux_option "@dracula-network-public-ip-label" "")
+  echo "$IP_LABEL $ip"
+}
+
+# run the main driver
+main


### PR DESCRIPTION
This plugin shows public IP at TMUX status line.

Color is configurable. Default foreground: cyan and background: dark_gray (inherits existing network plugin color scheme).
Label is configurable. Default empty string.  

Sample of plugin working. IP masked for privacy sake.
![image](https://github.com/dracula/tmux/assets/16687151/4b7e6083-b7b3-4b72-b086-b84ec30ae456)
