### PR TITLE
Added eks support for kubernetes prompt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -273,3 +273,29 @@ Set the label when there is one client, or more than one client
 set -g @dracula-clients-singular client
 set -g @dracula-clients-plural clients
 ```
+
+#### Kubernetes options
+
+Add prefix label before the context
+
+```bash
+set -g @dracula-kubernetes-context-label "Some Label"
+```
+
+Hide user from the context string
+
+```
+set -g @dracula-kubernetes-hide-user true
+```
+
+Hide ARN (show only cluster name) - Available for EKS only (only available for cluster names that are ARNs)
+
+```
+set -g @dracula-kubernetes-eks-hide-arn true
+```
+
+Extract the account as a prefix to the cluster name - Available for EKS only (only available for cluster names that are ARNs)
+
+```
+set -g @dracula-kubernetes-eks-extract-account true
+```

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -8,6 +8,10 @@ source $current_dir/utils.sh
 main()
 {
   # set configuration option variables
+  show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
+  eks_hide_arn=$(get_tmux_option "@dracula-kubernetes-eks-hide-arn" false)
+  eks_extract_account=$(get_tmux_option "@dracula-kubernetes-eks-extract-account" false)
+  hide_kubernetes_user=$(get_tmux_option "@dracula-kubernetes-hide-user" false)
   show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
   show_location=$(get_tmux_option "@dracula-show-location" true)
   fixed_location=$(get_tmux_option "@dracula-fixed-location")
@@ -23,7 +27,6 @@ main()
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
   time_format=$(get_tmux_option "@dracula-time-format" "")
-  show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
   IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
   show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
 
@@ -195,8 +198,7 @@ main()
 
     elif [ $plugin = "kubernetes-context" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")
-      script="#($current_dir/kubernetes_context.sh $show_kubernetes_context_label)"
-
+      script="#($current_dir/kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_kubernetes_context_label)"
     elif [ $plugin = "weather" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
       script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location $fixed_location)"

--- a/scripts/kubernetes_context.sh
+++ b/scripts/kubernetes_context.sh
@@ -2,7 +2,10 @@
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=en_US.UTF-8
 
-label=$1
+hide_arn_from_cluster=$1
+extract_account=$2
+hide_user=$3
+label=$4
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
@@ -12,11 +15,30 @@ current_user=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.na
 current_cluster=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.cluster}'; echo)
 current_namespace=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.namespace}'; echo)
 
+current_account_id=""
+if [[ "$current_cluster" =~ ^arn:aws:eks:[a-z0-9\-]*:[0-9]*:cluster/[a-z0-9\-]*$ ]]; then
+    if [ "$extract_account" = "true" ]; then
+        current_account_id=$(echo "$current_cluster" | cut -d':' -f5)
+    fi
+    if [ "$hide_arn_from_cluster" = "true" ]; then
+        current_cluster=${current_cluster##*/}
+    fi
+fi
+
+if [ "$hide_user" = "true" ]; then
+    current_user=""
+fi
+
 main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   OUTPUT_STRING=""
+  if [ ! -z "$current_account_id" ]
+  then
+      OUTPUT_STRING="${current_account_id}/"
+  fi
+
   if [ ! -z "$current_user" ]
   then
     OUTPUT_STRING="${current_user}@"


### PR DESCRIPTION
Makes the Kubernetes prompt more robust with the following:
* Ability to hide the ARN from the cluster name - only available for cluster whose names are ARNs
* Ability to extract account id (prefixed with account_id/<k8s-context>) - only available for clusters whose names are ARNs
* Ability to hide the user from the context (I already know who I am, this was just irrelevant and made the entire thing really bloated)

I'm well aware that the first feature (hide ARN) might be confusing, and can be controlled and renamed via kubeconfig, but I constantly move around and update my kubeconfig, between clusters of different clients, and it always overrides my existing renamed configurations.