### PR TITLE
fix bug with multi-word cwd

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -1,29 +1,24 @@
 #!/usr/bin/env bash
 
 # return current working directory of tmux pane
-getPaneDir()
-{
+getPaneDir() {
   nextone="false"
-  for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
-  do
-    if [ "$nextone" == "true" ]; then
-      echo $i
-      return
-    fi 
-    if [ "$i" == "1" ]; then
-      nextone="true"
-    fi
+  ret=""
+  for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}"); do
+    [ "$i" == "1" ] && nextone="true" && continue
+    [ "$i" == "0" ] && nextone="false"
+    [ "$nextone" == "true" ] && ret+="$i "
   done
+  echo "${ret%?}"
 }
 
-main()
-{
+main() {
   path=$(getPaneDir)
 
   # change '/home/user' to '~'
-  cwd=$(echo $path | sed "s;$HOME;~;g")
+  cwd="${path/"$HOME"/'~'}"
 
-  echo $cwd
+  echo "$cwd"
 }
 
 #run main driver program


### PR DESCRIPTION
I noticed that the cwd plugin fails with directory names that have spaces. Upon realizing this I want to fix my previous contribution. I pulled the function directly from the 'git' plugin but the for loop broke up multi-word directory names.

Previous:
![image](https://github.com/dracula/tmux/assets/99012095/20773271-a3df-4490-b33b-0c93951f15cc)


After changes:
![image](https://github.com/dracula/tmux/assets/99012095/ad1c0752-d4f2-43c9-acb8-7bc090782f93)

