### PR TITLE
Add tmux-ram-usage plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context
 
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
@@ -159,6 +159,14 @@ Customize label
 
 ```bash
 set -g @dracula-ram-usage-label "RAM"
+```
+
+#### tmux-ram-usage options
+
+Customize label
+
+```bash
+set -g @dracula-tmux-ram-usage-label "MEM"
 ```
 
 #### network-bandwidth

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - Battery percentage and AC power connection status
 - Refresh rate control
 - CPU usage (percentage or load average)
-- RAM usage
+- RAM usage (system and/or tmux server)
 - GPU usage
 - Custom status texts from external scripts
 - GPU VRAM usage

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -169,6 +169,10 @@ main()
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-ram-usage-colors" "cyan dark_gray")
       script="#($current_dir/ram_info.sh)"
 
+    elif [ $plugin = "tmux-ram-usage" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-tmux-ram-usage-colors" "cyan dark_gray")
+      script="#($current_dir/tmux_ram_info.sh)"
+
     elif [ $plugin = "network" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-colors" "cyan dark_gray")
       script="#($current_dir/network.sh)"

--- a/scripts/tmux_ram_info.sh
+++ b/scripts/tmux_ram_info.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+kb_to_mb() {
+  if [ $# == 0 ]; then
+    read num
+  else
+    num="$1"
+  fi
+  bc <<< "scale=3;$num/1024"
+}
+
+kb_to_gb() {
+  if [ $# == 0 ]; then
+    read num
+  else
+    num="$1"
+  fi
+  bc <<< "scale=6;$num/1048576"
+}
+
+round() {
+  if [ $# == 1 ]; then
+    read num
+    scale="$1"
+  elif [ $# == 2 ]; then
+    num="$1"
+    scale="$2"
+  fi
+  printf "%.${scale}f" "${num}"
+}
+
+get_tmux_ram_usage()
+{
+  local pid="$(tmux display-message -pF '#{pid}')"
+  local total_mem_kb=0
+  case $(uname -s) in
+    Linux)
+      local pids="$(pstree -p $pid | tr -d '\n' | sed -rn -e 's/[^()]*\(([0-9]+)\)[^()]*/\1,/g' -e 's/,$//p')"
+      total_mem_kb="$(ps -o rss= -p "$pids" | paste -sd+ | bc)"
+      ;;
+
+    Darwin)
+      local pids="$(pstree $pid | sed -En 's/[^0-9]+([0-9]+) .*/\1/p' | tr '\n' ',')"
+      total_mem_kb="$(ps -o rss= -p "$pids" | paste -sd+ - | bc)"
+      ;;
+
+    FreeBSD)
+      # TODO check FreeBSD compatibility
+      local pids="$(pstree $pid | sed -En 's/[^0-9]+([0-9]+) .*/\1/p' | tr '\n' ',')"
+      total_mem_kb="$(ps -o rss= -p "$pids" | paste -sd+ - | bc)"
+      ;;
+
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+      # TODO - windows compatability
+      ;;
+  esac
+  local total_mem_mb=$(echo "$total_mem_kb" | kb_to_mb | round 0)
+  local total_mem_gb=$(echo "$total_mem_kb" | kb_to_gb | round 0)
+
+  if (( $total_mem_gb > 0)); then
+    echo "${total_mem_gb}GB"
+  elif (( $total_mem_mb > 0 )); then
+    echo "${total_mem_mb}MB"
+  else
+    echo "${total_mem_kb}kB"
+  fi
+}
+
+main()
+{
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  ram_label=$(get_tmux_option "@dracula-tmux-ram-usage-label" "MEM")
+  ram_usage=$(get_tmux_ram_usage)
+  echo "$ram_label $ram_usage"
+}
+
+#run main driver
+main

--- a/scripts/tmux_ram_info.sh
+++ b/scripts/tmux_ram_info.sh
@@ -3,14 +3,14 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir/utils.sh"
 
 get_cpids_linux() {
   local ppid="$1"
   local cpids
-  cpids="$(pgrep -P "$ppid")"
   local cpid
   echo "$ppid"
+  cpids="$(pgrep -P "$ppid")"
   for cpid in $cpids; do
     get_cpids_linux "$cpid"
   done
@@ -19,9 +19,9 @@ get_cpids_linux() {
 get_cpids_unix() {
   local ppid="$1"
   local cpids
-  cpids="$(pgrep -aP "$ppid")"
   local cpid
   echo "$ppid"
+  cpids="$(pgrep -aP "$ppid")"
   for cpid in $cpids; do
     get_cpids_unix "$cpid"
   done
@@ -29,7 +29,7 @@ get_cpids_unix() {
 
 kb_to_mb() {
   if [ $# == 0 ]; then
-    read num
+    read -r num
   else
     num="$1"
   fi
@@ -38,7 +38,7 @@ kb_to_mb() {
 
 kb_to_gb() {
   if [ $# == 0 ]; then
-    read num
+    read -r num
   else
     num="$1"
   fi
@@ -47,7 +47,7 @@ kb_to_gb() {
 
 round() {
   if [ $# == 1 ]; then
-    read num
+    read -r num
     scale="$1"
   elif [ $# == 2 ]; then
     num="$1"
@@ -59,9 +59,11 @@ round() {
 get_tmux_ram_usage()
 {
   local pid
-  pid="$(tmux display-message -pF '#{pid}')"
   local pids
   local total_mem_kb=0
+  local total_mem_mb=0
+  local total_mem_gb=0
+  pid="$(tmux display-message -pF '#{pid}')"
   case $(uname -s) in
     Linux)
       if command -v pstree > /dev/null; then
@@ -95,12 +97,12 @@ get_tmux_ram_usage()
       # TODO - windows compatability
       ;;
   esac
-  local total_mem_mb=$(echo "$total_mem_kb" | kb_to_mb | round 0)
-  local total_mem_gb=$(echo "$total_mem_kb" | kb_to_gb | round 0)
+  total_mem_mb=$(kb_to_mb "$total_mem_kb" | round 0)
+  total_mem_gb=$(kb_to_gb "$total_mem_kb" | round 0)
 
-  if (( $total_mem_gb > 0)); then
+  if (( total_mem_gb > 0)); then
     echo "${total_mem_gb}GB"
-  elif (( $total_mem_mb > 0 )); then
+  elif (( total_mem_mb > 0 )); then
     echo "${total_mem_mb}MB"
   else
     echo "${total_mem_kb}kB"
@@ -109,8 +111,6 @@ get_tmux_ram_usage()
 
 main()
 {
-  # storing the refresh rate in the variable RATE, default is 5
-  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   ram_label=$(get_tmux_option "@dracula-tmux-ram-usage-label" "MEM")
   ram_usage=$(get_tmux_ram_usage)
   echo "$ram_label $ram_usage"


### PR DESCRIPTION
This shows the total RAM usage of the tmux server and all child processes. ~~Requires `pstree`~~.

Example (in purple):
<img width="395" alt="image" src="https://github.com/dracula/tmux/assets/7785912/78ff9847-1679-419f-85f9-20d8b0b8ca14">
