### PR TITLE
Add tmux-continuum status plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -322,20 +322,17 @@ set -g @dracula-clients-plural clients
 
 #### continuum options
 
-Hide output if no save has been performed recently
-(otherwise, show the continuum save interval)
+Set the output mode. Options are:
+- **countdown**: Show a T- countdown to the next save (default)
+- **time**: Show the time since the last save
+- **alert**: Hide output if no save has been performed recently
+- **interval**: Show the continuum save interval
 
 ```bash
-set -g @dracula-continuum-mode alert
+set -g @dracula-continuum-mode countdown
 ```
 
-Show the time since the last continuum save
-
-```bash
-set -g @dracula-continuum-mode time
-```
-
-In alert mode, show if a the last save was performed less then one minute ago (default is 15 seconds)
+Show if the last save was performed less than 60 seconds ago (default threshold is 15 seconds)
 
 ```bash
 set -g @dracula-continuum-time-threshold 60

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -319,3 +319,24 @@ Set the label when there is one client, or more than one client
 set -g @dracula-clients-singular client
 set -g @dracula-clients-plural clients
 ```
+
+#### continuum options
+
+Hide output if no save has been performed recently
+(otherwise, show the continuum save interval)
+
+```bash
+set -g @dracula-continuum-mode alert
+```
+
+Show the time since the last continuum save
+
+```bash
+set -g @dracula-continuum-mode time
+```
+
+In alert mode, show if a the last save was performed less then one minute ago (default is 15 seconds)
+
+```bash
+set -g @dracula-continuum-time-threshold 60
+```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - Info if the Panes are synchronized
 - Spotify playback (needs the tool spotify-tui installed)
 - Current kubernetes context
+- Countdown to tmux-continuum save
 - Current working directory of tmux pane
 
 ## Compatibility

--- a/scripts/continuum.sh
+++ b/scripts/continuum.sh
@@ -129,7 +129,7 @@ print_status() {
         time_delta="$(($(current_timestamp) - last_continuum_timestamp))"
         time_delta_minutes="$((time_delta / 60))"
 
-        status="$status; next: T$(printf '%+d' "$((time_delta_minutes - save_int))")min"
+        status="$status; T$(printf '%+d' "$((time_delta_minutes - save_int))")min"
       fi
     elif [[ "$time_delta" -le "$info_threshold" ]]; then
       status="saved"

--- a/scripts/continuum.sh
+++ b/scripts/continuum.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+# configuration
+# @dracula-continuum-mode default (default|alert|time)
+# @dracula-continuum-time-threshold 15
+
+alert_mode="@dracula-continuum-mode"
+time_threshold="@dracula-continuum-time-threshold"
+warn_threshold=15
+
+last_auto_save_option="@continuum-save-last-timestamp"
+auto_save_interval_option="@continuum-save-interval"
+auto_save_interval_default="15"
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source $current_dir/utils.sh
+
+current_timestamp() {
+  echo "$(date +%s)"
+}
+
+time_since_last_run_passed() {
+  local last_saved_timestamp="$(get_tmux_option "$last_auto_save_option" "0")"
+  printf "%s" "$(($(current_timestamp) - last_saved_timestamp))"
+}
+
+print_status() {
+  local mode="$(get_tmux_option "$alert_mode" "default")"
+  local threshold="$(get_tmux_option "$time_threshold" "15")"
+  local save_int="$(get_tmux_option "$auto_save_interval_option" "$auto_save_interval_default")"
+  local interval_seconds="$((save_int * 60))"
+  local status=""
+  local time_delta="$(time_since_last_run_passed)"
+  local time_delta_minutes="$((time_delta / 60))"
+
+  case "$mode" in
+    time)
+      if [[ $save_int -gt 0 ]]; then
+        if [[ "$time_delta" -gt $((interval_seconds+warn_threshold)) ]]; then
+          status="no save after $time_delta_minutes minutes!"
+        else
+          status="$time_delta_minutes"
+        fi
+      else
+        status="off"
+      fi
+      ;;
+
+    alert)
+      if [[ "$time_delta" -gt $((interval_seconds+warn_threshold)) ]]; then
+        status="no save after $time_delta_minutes minutes!"
+      elif [[ "$time_delta" -le "$threshold" ]]; then
+        status="saved"
+      elif [[ $save_int -gt 0 ]]; then
+        status=""
+      else
+        status="off"
+      fi
+      ;;
+
+    *)
+      if [[ "$time_delta" -le "$threshold" ]]; then
+        status="saved"
+      elif [[ $save_int -gt 0 ]]; then
+        status="$save_int"
+      else
+        status="off"
+      fi
+      ;;
+  esac
+  echo "$status"
+}
+print_status

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -212,6 +212,10 @@ main()
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-terraform-colors" "light_purple dark_gray")
       script="#($current_dir/terraform.sh $terraform_label)"
 
+    elif [ $plugin = "continuum" ]; then
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-continuum-colors" "cyan dark_gray")
+      script="#($current_dir/continuum.sh)"
+
     elif [ $plugin = "weather" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
       script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location $fixed_location)"


### PR DESCRIPTION
This PR shows the status of the latest [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) save and a countdown to the next save.

If no save is present:
<img width="526" alt="Screenshot 2023-06-17 at 5 09 58 PM" src="https://github.com/dracula/tmux/assets/7785912/d70031a5-3377-41ea-a34f-2bd414d2852e">
When a save occurs:
<img width="526" alt="Screenshot 2023-06-17 at 5 24 57 PM" src="https://github.com/dracula/tmux/assets/7785912/7c7889a6-887a-4c8b-806c-8142845004e2">
Then the timer resets:
<img width="526" alt="Screenshot 2023-06-17 at 5 25 11 PM" src="https://github.com/dracula/tmux/assets/7785912/318b3460-5b9b-44f4-b1ae-cf7fc38be2d0">

