### PR TITLE
Improve customization

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -10,7 +10,7 @@ get_percent()
   case $(uname -s) in
     Linux)
       percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
-      normalize_percent_len $percent
+      normalize_string_length $percent
       ;;
 
     Darwin)
@@ -20,7 +20,7 @@ get_percent()
       percent="$cpuusage%"
       # a/b will get a integer, no decimal, like "1%" or "99%".
       # So set the length to 3 below.
-      normalize_percent_len $percent 3
+      normalize_string_length $percent 3
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -18,7 +18,9 @@ get_percent()
       cpucores=$(sysctl -n hw.logicalcpu)
       cpuusage=$(( cpuvalue / cpucores ))
       percent="$cpuusage%"
-      normalize_percent_len $percent
+      # a/b will get a integer, no decimal, like "1%" or "99%".
+      # So set the length to 3 below.
+      normalize_percent_len $percent 3
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -6,6 +6,7 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 
 main()
+{
 
 # # Main Structure
 # - Color Pallette
@@ -18,7 +19,6 @@ main()
 # - Window Area
 # - Right Plugins Area
 
-{
 
 # Dracula Color Pallette{
   white='#f8f8f2'
@@ -42,13 +42,21 @@ main()
   show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
   show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
   show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
+  status_bg=$(get_tmux_option "@dracula-status-bg" gray)
 
   # left icon area
-  show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
-  show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
+  left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
+  left_icon_bg=$(get_tmux_option "@dracula-left-icon-bg" green)
+  left_icon_fg=$(get_tmux_option "@dracula-left-icon-fg" dark_gray)
+  left_icon_prefix_bg=$(get_tmux_option "@dracula-left-icon-prefix-on-bg" red)
+  left_icon_prefix_fg=$(get_tmux_option "@dracula-left-icon-prefix-on-fg" white)
+  left_icon_padding_left=$(get_tmux_option "@dracula-left-icon-padding-left" 1)
+  left_icon_padding_right=$(get_tmux_option "@dracula-left-icon-padding-right" 1)
+  left_icon_margin_right=$(get_tmux_option "@dracula-left-icon-margin-right" 1)
 
   # window area
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
+  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
 
   # right plugins area
   # plugins general
@@ -71,7 +79,6 @@ main()
 
   # kubernetes-context
   show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
-  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
 # }
 
 
@@ -82,8 +89,13 @@ main()
 
   # Handle powerline option
   if $show_powerline; then
-    right_sep="$show_right_sep"
     left_sep="$show_left_sep"
+    right_sep="$show_right_sep"
+  else  # if disable powerline mark, equal to '', unify the logic of string.
+    left_sep=''
+    right_sep=''
+    window_left_sep=''
+    window_right_sep=''
   fi
 
   # set length
@@ -102,37 +114,50 @@ main()
   tmux set-option -g message-style "bg=${gray},fg=${white}"
 
   # status bar
-  tmux set-option -g status-style "bg=${gray},fg=${white}"
+  tmux set-option -g status-style "bg=${!status_bg},fg=${white}"
 # }
 
 
 # Left Icon Area {
   # Handle left icon configuration
-  case $show_left_icon in
+  case $left_icon in
     smiley)
-      left_icon="☺";;
+      left_icon_content="☺";;
     session)
-      left_icon="#S";;
+      left_icon_content="#S";;
     window)
-      left_icon="#W";;
+      left_icon_content="#W";;
     *)
-      left_icon=$show_left_icon;;
+      left_icon_content=$left_icon;;
   esac
 
   # Handle left icon padding
-  padding=""
-  if [ "$show_left_icon_padding" -gt "0" ]; then
-    padding="$(printf '%*s' $show_left_icon_padding)"
+  icon_pd_l=""
+  if [ "$left_icon_padding_left" -gt "0" ]; then
+    icon_pd_l="$(printf '%*s' $left_icon_padding_left)"
   fi
-  left_icon="$left_icon$padding"
+  icon_pd_r=""
+  if [ "$left_icon_padding_right" -gt "0" ]; then
+    icon_pd_r="$(printf '%*s' $left_icon_padding_right)"
+  fi
 
-  # Status left
-  if $show_powerline; then
-    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
-    powerbg=${gray}
-  else
-    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
+  # Handle left icon margin
+  icon_mg_r=""
+  if [ "$left_icon_margin_right" -gt "0" ]; then
+    icon_mg_r="$(printf '%*s' $left_icon_margin_right)"
   fi
+
+  # Left icon, with prefix status
+  tmux set-option -g status-left "\
+#{?client_prefix,#[fg=${!left_icon_prefix_fg}],#[fg=${!left_icon_fg}]}\
+#{?client_prefix,#[bg=${!left_icon_prefix_bg}],#[bg=${!left_icon_bg}]}\
+${icon_pd_l}${left_icon_content}${icon_pd_r}\
+#{?client_prefix,#[fg=${!left_icon_prefix_bg}],#[fg=${!left_icon_bg}]}\
+#[bg=${!status_bg}]\
+${left_sep}\
+${icon_mg_r}"
+  powerbg=${!status_bg}
+
 # }
 
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -6,29 +6,21 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 
 main()
-{
-  # set configuration option variables
-  terraform_label=$(get_tmux_option "@dracula-terraform-label" "")
-  show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
-  show_location=$(get_tmux_option "@dracula-show-location" true)
-  fixed_location=$(get_tmux_option "@dracula-fixed-location")
-  show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
-  show_flags=$(get_tmux_option "@dracula-show-flags" false)
-  show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
-  show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
-  show_military=$(get_tmux_option "@dracula-military-time" false)
-  show_timezone=$(get_tmux_option "@dracula-show-timezone" true)
-  show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
-  show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
-  show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
-  show_day_month=$(get_tmux_option "@dracula-day-month" false)
-  show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
-  time_format=$(get_tmux_option "@dracula-time-format" "")
-  show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
-  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
-  show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
 
-  # Dracula Color Pallette
+# # Main Structure
+# - Color Pallette
+# - Get Tmux Option Variables
+#   - General
+#   - For Left Icon
+#   - For Window
+#   - For Plugins
+# - Left Icon Area
+# - Window Area
+# - Right Plugins Area
+
+{
+
+# Dracula Color Pallette{
   white='#f8f8f2'
   gray='#44475a'
   dark_gray='#282a36'
@@ -40,57 +32,58 @@ main()
   red='#ff5555'
   pink='#ff79c6'
   yellow='#f1fa8c'
+# }
 
-  # Handle left icon configuration
-  case $show_left_icon in
-    smiley)
-      left_icon="☺";;
-    session)
-      left_icon="#S";;
-    window)
-      left_icon="#W";;
-    *)
-      left_icon=$show_left_icon;;
-  esac
 
-  # Handle left icon padding
-  padding=""
-  if [ "$show_left_icon_padding" -gt "0" ]; then
-    padding="$(printf '%*s' $show_left_icon_padding)"
-  fi
-  left_icon="$left_icon$padding"
+# Get Tmux Option Variables {
+
+  # general
+  show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
+  show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
+  show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
+  show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
+
+  # left icon area
+  show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
+  show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
+
+  # window area
+  show_flags=$(get_tmux_option "@dracula-show-flags" false)
+
+  # right plugins area
+  # plugins general
+  show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
+  show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
+
+  # terraform
+  terraform_label=$(get_tmux_option "@dracula-terraform-label" "")
+
+  # weather
+  show_fahrenheit=$(get_tmux_option "@dracula-show-fahrenheit" true)
+  show_location=$(get_tmux_option "@dracula-show-location" true)
+  fixed_location=$(get_tmux_option "@dracula-fixed-location")
+
+  # time
+  show_military=$(get_tmux_option "@dracula-military-time" false)
+  show_timezone=$(get_tmux_option "@dracula-show-timezone" true)
+  show_day_month=$(get_tmux_option "@dracula-day-month" false)
+  time_format=$(get_tmux_option "@dracula-time-format" "")
+
+  # kubernetes-context
+  show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
+  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
+# }
+
+
+# General Settings {
+
+  # sets refresh interval to every 5 seconds
+  tmux set-option -g status-interval $show_refresh
 
   # Handle powerline option
   if $show_powerline; then
     right_sep="$show_right_sep"
     left_sep="$show_left_sep"
-  fi
-
-  # Set timezone unless hidden by configuration
-  case $show_timezone in
-    false)
-      timezone="";;
-    true)
-      timezone="#(date +%Z)";;
-  esac
-
-  case $show_flags in
-    false)
-      flags=""
-      current_flags="";;
-    true)
-      flags="#{?window_flags,#[fg=${dark_purple}]#{window_flags},}"
-      current_flags="#{?window_flags,#[fg=${light_purple}]#{window_flags},}"
-  esac
-
-  # sets refresh interval to every 5 seconds
-  tmux set-option -g status-interval $show_refresh
-
-  # set the prefix + t time format
-  if $show_military; then
-    tmux set-option -g clock-mode-style 24
-  else
-    tmux set-option -g clock-mode-style 12
   fi
 
   # set length
@@ -110,6 +103,28 @@ main()
 
   # status bar
   tmux set-option -g status-style "bg=${gray},fg=${white}"
+# }
+
+
+# Left Icon Area {
+  # Handle left icon configuration
+  case $show_left_icon in
+    smiley)
+      left_icon="☺";;
+    session)
+      left_icon="#S";;
+    window)
+      left_icon="#W";;
+    *)
+      left_icon=$show_left_icon;;
+  esac
+
+  # Handle left icon padding
+  padding=""
+  if [ "$show_left_icon_padding" -gt "0" ]; then
+    padding="$(printf '%*s' $show_left_icon_padding)"
+  fi
+  left_icon="$left_icon$padding"
 
   # Status left
   if $show_powerline; then
@@ -118,9 +133,53 @@ main()
   else
     tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
   fi
+# }
 
-  # Status right
+
+# Window Area {
+
+  # Handle window flags
+  case $show_flags in
+    false)
+      flags=""
+      current_flags="";;
+    true)
+      flags="#{?window_flags,#[fg=${dark_purple}]#{window_flags},}"
+      current_flags="#{?window_flags,#[fg=${light_purple}]#{window_flags},}"
+  esac
+
+  # Window option
+  if $show_powerline; then
+    tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
+  else
+    tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
+  fi
+
+  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W${flags}"
+
+  tmux set-window-option -g window-status-activity-style "bold"
+  tmux set-window-option -g window-status-bell-style "bold"
+
+# }
+
+# Right Plugins Area{
   tmux set-option -g status-right ""
+
+  # Set timezone unless hidden by configuration
+  case $show_timezone in
+    false)
+      timezone="";;
+    true)
+      timezone="#(date +%Z)";;
+  esac
+
+  # set the prefix + t time format
+  if $show_military; then
+    tmux set-option -g clock-mode-style 24
+  else
+    tmux set-option -g clock-mode-style 12
+  fi
+
 
   for plugin in "${plugins[@]}"; do
 
@@ -241,17 +300,6 @@ main()
       fi
     fi
   done
-
-  # Window option
-  if $show_powerline; then
-    tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
-  else
-    tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
-  fi
-
-  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W${flags}"
-  tmux set-window-option -g window-status-activity-style "bold"
-  tmux set-window-option -g window-status-bell-style "bold"
 }
 
 # run main function

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -32,7 +32,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  normalize_string_length $usage
 }
 
 main()

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -31,7 +31,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  normalize_string_length $usage
 }
 
 main()

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -31,7 +31,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  normalize_string_length $usage
 }
 
 main()

--- a/scripts/network_ping.sh
+++ b/scripts/network_ping.sh
@@ -15,7 +15,7 @@ ping_function() {
     # storing the hostname/IP in the variable PINGSERVER, default is google.com
     pingserver=$(get_tmux_option "@dracula-ping-server" "google.com")
     pingtime=$(ping -c 1 "$pingserver" | tail -1 | awk '{print $4}' | cut -d '/' -f 2)
-    echo "$pingtime ms"
+    echo "${pingtime%.*}ms"  # Truncate the integer part
     ;;
 
   CYGWIN* | MINGW32* | MSYS* | MINGW*)
@@ -26,7 +26,10 @@ ping_function() {
 
 main() {
 
-  echo $(ping_function)
+  # Label Ref           
+  ping_label=$(get_tmux_option "@dracula-ping-label" "Ping")
+  echo "$ping_label $(ping_function)"
+
   RATE=$(get_tmux_option "@dracula-ping-rate" 5)
   sleep $RATE
 }

--- a/scripts/network_ping.sh
+++ b/scripts/network_ping.sh
@@ -15,7 +15,9 @@ ping_function() {
     # storing the hostname/IP in the variable PINGSERVER, default is google.com
     pingserver=$(get_tmux_option "@dracula-ping-server" "google.com")
     pingtime=$(ping -c 1 "$pingserver" | tail -1 | awk '{print $4}' | cut -d '/' -f 2)
-    echo "${pingtime%.*}ms"  # Truncate the integer part
+    # Truncate the integer part
+    # Network ping doesn't always stable, so keep min length to 5(999ms).
+    normalize_string_length "${pingtime%.*}ms" 5
     ;;
 
   CYGWIN* | MINGW32* | MSYS* | MINGW*)

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -11,15 +11,29 @@ get_tmux_option() {
   fi
 }
 
-# normalize the percentage string to always have a length of 5
+# normalize the percentage string to customize length and align
+# $1 percentage string
+# $2 max length, default is 3 (99%)
+# $3 align (left, center, right), default is right
 normalize_percent_len() {
-  # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
-  max_len=5
+  # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%".
   percent_len=${#1}
+  max_len=${2:-5}  # default
+  align=${3:-'right'}
   let diff_len=$max_len-$percent_len
-  # if the diff_len is even, left will have 1 more space than right
-  let left_spaces=($diff_len+1)/2
-  let right_spaces=($diff_len)/2
+  case $align in
+    'center')
+      # if the diff_len is even, left will have 1 more space than right
+      let left_spaces=($diff_len+1)/2
+      let right_spaces=($diff_len)/2;;
+    'left')
+      let left_spaces=0
+      let right_spaces=$diff_len;;
+    'right')
+      let left_spaces=$diff_len
+      let right_spaces=0;;
+  esac
+
   printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
 }
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -15,7 +15,7 @@ get_tmux_option() {
 # $1 percentage string
 # $2 max length, default is 3 (99%)
 # $3 align (left, center, right), default is right
-normalize_percent_len() {
+normalize_string_length() {
   # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%".
   percent_len=${#1}
   max_len=${2:-5}  # default


### PR DESCRIPTION
I took the liberty of rearranging the code and made a lot of changes at once. I hope these changes are useful and not too difficult to understand.

Because I work as an artist in a gaming company, the changes mainly focus on spacing, color, icons, etc.

<img width="1440" alt="image" src="https://github.com/dracula/tmux/assets/17139670/117cee57-d3d3-4898-9eed-cedec31dd987">

## Rearrange

The previous code may have gone through multiple additions, so after I made changes, the new code I added looked even more messy. So in the end, I adjusted the order of the code and its naming consistency. However, I did not adjust the name of tmux's options to ensure backward compatibility.

The new code follows the following rules.

- Color Palette
- Get Tmux Option Variables
    - General
    - For Left Icon
    - For Window
    - For Plugins
- Left Icon Area
- Window Area
- Right Plugins Area

## Left Icon Area

- Add padding & margin
- Add customized color for prefix status (Previous is )
- Remove too many if, and standardize the logic for enabling or disabling powerline.
- status_bg -> variable

Here is my configuration, and **all default values that have not been changed**.
![Left-Icon](https://github.com/dracula/tmux/assets/17139670/146f9bf7-3205-4314-9728-d7a48bb59d50)

### Handling of show_powerline

In the previous version, there were many `if` statements used to handle `show_powerline`.
However, I believe it is simply a marker. If `show_powerline` is not enabled, changing the marker to blank (`""`) would suffice. Although there are still several color operations of the blank that need to be handled, it is better than duplicating everything.

## Window Area

- Customize color
- Customize separator (can invert left sep color)
- Customize padding & margin
- Remove the color of flags (follow the fg)
- The window tab will maintain a consistent width regardless of focus.
  The tab will not suddenly change while you switch between windows.
  (Flags will change the width)

![Window](https://github.com/dracula/tmux/assets/17139670/38a6529d-69ba-49a7-addc-d73c5c0fa234)

### Disable dracula's window settings

If you turn `@dracula-window-disabled` to true, all the window settings in `dracula.sh` won't be rendered, and `.tmux.conf` works. You can do some complex things as you wish.

<img width="1440" alt="image" src="https://github.com/dracula/tmux/assets/17139670/eaea69e9-b686-48b5-98e8-f66f2659c19e">

- Index: Window name > folder of the current pane
- You can also display the number of panes, current program, etc.

## Plugins Area

- Customize each side padding (rightmost separately)
- Fix the padding of the timezone string.
  If the timezone existed, add one space before the timezone. If not, there's nothing.
  (Prev version always adds an extra space)


![Plugins](https://github.com/dracula/tmux/assets/17139670/068ba162-48b1-4980-9102-fa5059508504)

## P.S.

In my daily work, I primarily write Python and front-end projects, and I rarely write Shell scripts. So, I am concerned about making errors and would greatly appreciate a review of my work.
