### PR TITLE
Add mercurial script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -239,6 +239,25 @@ Show remote tracking branch together with diverge/sync state
 set -g @dracula-git-show-remote-status true
 ```
 
+#### mercurial options
+
+Hide details of hg changes
+```bash
+set -g @dracula-hg-disable-status true
+```
+
+Set symbol or message to use when the current pane has no hg repo
+```bash
+# default is unicode no message
+set -g @dracula-hg-no-repo-message ""
+```
+
+Hide untracked files from being displayed as local changes
+```bash
+# default is false
+set -g @dracula-hg-no-untracked-files true
+```
+
 #### weather options
 
 Switch from default fahrenheit to celsius

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -239,23 +239,35 @@ Show remote tracking branch together with diverge/sync state
 set -g @dracula-git-show-remote-status true
 ```
 
-#### mercurial options
+#### hg options
 
 Hide details of hg changes
 ```bash
 set -g @dracula-hg-disable-status true
 ```
 
+Set symbol to use for when branch is up to date with HEAD
+```bash
+#default is ✓.Avoid using non unicode characters that bash uses like $, * and !
+set -g @dracula-hg-show-current-symbol ✓
+```
+
+Set symbol to use for when branch diverges from HEAD
+```bash
+#default is unicode !.Avoid bash special characters
+set -g @dracula-hg-show-diff-symbol !
+```
+
 Set symbol or message to use when the current pane has no hg repo
 ```bash
-# default is unicode no message
+#default is unicode no message
 set -g @dracula-hg-no-repo-message ""
 ```
 
 Hide untracked files from being displayed as local changes
 ```bash
-# default is false
-set -g @dracula-hg-no-untracked-files true
+#default is false
+set -g @dracula-hg-no-untracked-files false
 ```
 
 #### weather options
@@ -292,3 +304,4 @@ Set the label when there is one client, or more than one client
 set -g @dracula-clients-singular client
 set -g @dracula-clients-plural clients
 ```
+

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -145,6 +145,11 @@ main()
       tmux set-option -g status-right-length 250
       script="#($current_dir/git.sh)"
 
+    elif [ $plugin = "hg" ]; then
+      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-hg-colors" "green dark_gray")
+      tmux set-option -g status-right-length 250
+      script="#($current_dir/hg.sh)"
+
     elif [ $plugin = "battery" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")
       script="#($current_dir/battery.sh)"

--- a/scripts/hg.sh
+++ b/scripts/hg.sh
@@ -24,7 +24,7 @@ for i in $(hg -R $path status -admru)
       'A')
         added+=1
       ;;
-      'D')
+      '!')
        deleted+=1
       ;;
       'M')

--- a/scripts/hg.sh
+++ b/scripts/hg.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+IFS=' ' read -r -a hide_status <<< $(get_tmux_option "@dracula-hg-disable-status" "false")
+IFS=' ' read -r -a current_symbol <<< $(get_tmux_option "@dracula-hg-show-current-symbol" "✓")
+IFS=' ' read -r -a diff_symbol <<< $(get_tmux_option "@dracula-hg-show-diff-symbol" "!")
+IFS=' ' read -r -a no_repo_message <<< $(get_tmux_option "@dracula-hg-no-repo-message" "")
+IFS=' ' read -r -a no_untracked_files <<< $(get_tmux_option "@dracula-hg-no-untracked-files" "false")
+
+# Get added, modified, and removed files from hg status
+getChanges()
+{
+   declare -i added=0;
+   declare -i deleted=0;
+   declare -i modified=0;
+   declare -i removed=0;
+   declare -i untracked=0;
+
+for i in $(hg -R $path status -admru)
+    do
+      case $i in
+      'A')
+        added+=1
+      ;;
+      'D')
+       deleted+=1
+      ;;
+      'M')
+        modified+=1
+      ;;
+      'R')
+       removed+=1
+      ;;
+      '?')
+       untracked+=1
+      ;;
+
+      esac
+    done
+
+    output=""
+    [ $added -gt 0 ] && output+="${added}A"
+    [ $modified -gt 0 ] && output+=" ${modified}M"
+    [ $deleted -gt 0 ] && output+=" ${deleted}D"
+    [ $removed -gt 0 ] && output+=" ${removed}R"
+    [ $no_untracked_files == "false" -a $untracked -gt 0 ] && output+=" ${untracked}?"
+
+    echo $output
+}
+
+
+# getting the #{pane_current_path} from dracula.sh is no longer possible
+getPaneDir()
+{
+ nextone="false"
+ for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
+ do
+    if [ "$nextone" == "true" ]; then
+       echo $i
+       return
+    fi
+    if [ "$i" == "1" ]; then
+        nextone="true"
+    fi
+  done
+}
+
+
+# check if the current or diff symbol is empty to remove ugly padding
+checkEmptySymbol()
+{
+    symbol=$1
+    if [ "$symbol" == "" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# check to see if the current repo is not up to date with HEAD
+checkForChanges()
+{
+    [ $no_untracked_files == "false" ] && no_untracked="-u" || no_untracked=""
+    if [ "$(checkForHgDir)" == "true" ]; then
+        if [ "$(hg -R $path status -admr $no_untracked)" != "" ]; then
+            echo "true"
+        else
+            echo "false"
+        fi
+    else
+        echo "false"
+    fi
+}
+
+# check if a hg repo exists in the directory
+checkForHgDir()
+{
+    if [ "$(hg -R $path branch)" != "" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# return branch name if there is one
+getBranch()
+{
+    if [ $(checkForHgDir) == "true" ]; then
+        echo $(hg -R $path branch)
+    else
+        echo $no_repo_message
+    fi
+}
+
+# return the final message for the status bar
+getMessage()
+{
+    if [ $(checkForHgDir) == "true" ]; then
+        branch="$(getBranch)"
+        output=""
+
+        if [ $(checkForChanges) == "true" ]; then
+
+            changes="$(getChanges)"
+
+            if [ "${hide_status}" == "false" ]; then
+                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+		     output=$(echo "${changes} $branch")
+                else
+		     output=$(echo "$diff_symbol ${changes} $branch")
+                fi
+            else
+                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+		     output=$(echo "$branch")
+                else
+		     output=$(echo "$diff_symbol $branch")
+                fi
+            fi
+
+        else
+            if [ $(checkEmptySymbol $current_symbol) == "true" ]; then
+	         output=$(echo "$branch")
+            else
+		 output=$(echo "$current_symbol $branch")
+            fi
+        fi
+
+        echo "$output"
+    else
+        echo $no_repo_message
+    fi
+}
+
+main()
+{
+    path=$(getPaneDir)
+    getMessage
+}
+
+#run main driver program
+main


### PR DESCRIPTION
I added support for tracking mercurial repositories similar to the existing git repository support.

```
set -g @dracula-plugins "hg time"
```

Clean repository
![clean](https://github.com/dracula/tmux/assets/876723/2ecefa29-ea1d-48ba-be1e-f0d01e5c6833)

Dirty repository
![dirty](https://github.com/dracula/tmux/assets/876723/bee0f899-72da-4317-b58c-29dd7f2f6a0c)

Tested each configuration:
```
set -g @dracula-hg-disable-status true
set -g @dracula-hg-show-diff-symbol "^"
```
![hg-disable-status](https://github.com/dracula/tmux/assets/876723/5b5aaace-4b1c-4591-8f64-a7ee578374c9)

```
set -g @dracula-hg-no-untracked-files true
```
![no-untracked-files](https://github.com/dracula/tmux/assets/876723/6b83e9b1-bf2b-4a1a-9ec4-f7aefa01aadf)


```
set -g @dracula-hg-no-repo-message "no-hg"
```
![hg-no-repo-message](https://github.com/dracula/tmux/assets/876723/938e395e-ec6d-45ac-8908-30c27c128486)



```
set -g @dracula-hg-show-current-symbol "@"
```
![hg-show-current-symbol](https://github.com/dracula/tmux/assets/876723/28c168d7-1582-4486-b520-42d707bcf58a)


