### PR TITLE
Add ssh-session plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context, synchronize-panes
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, ssh-session, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context, synchronize-panes
 
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
@@ -188,6 +188,13 @@ You can configure which server (hostname, IP) you want to ping and at which rate
 ```bash
 set -g @dracula-ping-server "google.com"
 set -g @dracula-ping-rate 5
+```
+### ssh-session options
+
+Show SSH session port
+
+```bash
+set -g @dracula-show-ssh-session-port true
 ```
 
 #### time options

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - Day, date, time, timezone
 - Current location based on network with temperature and forecast icon (if available)
 - Network connection status, bandwidth and SSID
+- SSH session user, hostname and port of active tmux pane
 - Git branch and status
 - Battery percentage and AC power connection status
 - Refresh rate control

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -30,6 +30,7 @@ main()
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
   show_synchronize_panes_label=$(get_tmux_option "@dracula-synchronize-panes-label" "Sync")
   time_format=$(get_tmux_option "@dracula-time-format" "")
+  show_ssh_session_port=$(get_tmux_option "@dracula-show-ssh-session-port" false)
   IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
   show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
 
@@ -146,7 +147,7 @@ main()
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")
       tmux set-option -g status-right-length 250
       script="#($current_dir/cwd.sh)"
-    
+
     elif [ $plugin = "fossil" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-fossil-colors" "green dark_gray")
       tmux set-option -g status-right-length 250
@@ -249,6 +250,11 @@ main()
     elif [ $plugin = "synchronize-panes" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-synchronize-panes-colors" "cyan dark_gray")
       script="#($current_dir/synchronize_panes.sh $show_synchronize_panes_label)"
+
+    elif [ $plugin = "ssh-session" ]; then
+      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-ssh-session-colors" "green dark_gray")
+      script="#($current_dir/ssh_session.sh $show_ssh_session_port)"
+
     else
       continue
     fi

--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -39,6 +39,26 @@ get_ssh_user() {
     fi
   done
 
+  for ssh_config in `awk '
+    $1 == "Host" {
+      gsub("\\\\.", "\\\\.", $2);
+      gsub("\\\\*", ".*", $2);
+      host = $2;
+      next;
+    }
+    $1 == "User" {
+      $1 = "";
+      sub( /^[[:space:]]*/, "" );
+      printf "%s|%s\n", host, $0;
+    }' .ssh/config`; do
+    local host_regex=${ssh_config%|*}
+    local host_user=${ssh_config#*|}
+    if [[ "$1" =~ $host_regex ]]; then
+      ssh_user=$host_user
+      break
+    fi
+  done
+
   echo $ssh_user
 }
 

--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+show_ssh_session_port=$1
+
+parse_ssh_port() {
+  # Get port from connection
+  local port=$(echo $1|grep -Eo '\-p\s*([0-9]+)'|sed 's/-p\s*//')
+
+  if [ -z $port ]; then
+    local port=22
+  fi
+
+  echo $port
+}
+
+get_ssh_user() {
+  local ssh_user=$(whoami)
+
+  for ssh_config in `awk '
+    $1 == "Host" {
+      gsub("\\\\.", "\\\\.", $2);
+      gsub("\\\\*", ".*", $2);
+      host = $2;
+      next;
+    }
+    $1 == "User" {
+      $1 = "";
+      sub( /^[[:space:]]*/, "" );
+      printf "%s|%s\n", host, $0;
+    }' .ssh/config`; do
+    local host_regex=${ssh_config%|*}
+    local host_user=${ssh_config#*|}
+    if [[ "$1" =~ $host_regex ]]; then
+      ssh_user=$host_user
+      break
+    fi
+  done
+
+  echo $ssh_user
+}
+
+get_remote_info() {
+  local command=$1
+
+  # First get the current pane command pid to get the full command with arguments
+  local cmd=$({ pgrep -flaP `tmux display-message -p "#{pane_pid}"` ; ps -o command -p `tmux display-message -p "#{pane_pid}"` ; } | xargs -I{} echo {} | grep ssh | sed -E 's/^[0-9]*[[:blank:]]*ssh //')
+  local port=$(parse_ssh_port "$cmd")
+
+  local cmd=$(echo $cmd|sed 's/\-p\s*'"$port"'//g')
+  local user=$(echo $cmd | awk '{print $NF}'|cut -f1 -d@)
+  local host=$(echo $cmd | awk '{print $NF}'|cut -f2 -d@)
+
+  if [ $user == $host ]; then
+    local user=$(get_ssh_user $host)
+  fi
+
+  case "$1" in
+    "whoami")
+      echo $user
+      ;;
+    "hostname")
+      echo $host
+      ;;
+    "port")
+      echo $port
+      ;;
+    *)
+      echo "$user@$host:$port"
+      ;;
+  esac
+}
+
+get_info() {
+  # If command is ssh get info from remote
+  if $(ssh_connected); then
+    echo $(get_remote_info $1)
+  else
+    echo $($1)
+  fi
+}
+
+ssh_connected() {
+  # Get current pane command
+  local cmd=$(tmux display-message -p "#{pane_current_command}")
+
+  [ $cmd = "ssh" ] || [ $cmd = "sshpass" ]
+}
+
+main() {
+  hostname=$(get_info hostname)
+  user=$(get_info whoami)
+
+  # Only show port info if ssh session connected (no localhost) and option enabled
+  if $(ssh_connected) && [[ $show_ssh_session_port == "true" ]] ; then
+    port=$(get_info port)
+    echo $user@$hostname:$port
+  else
+    echo $user@$hostname
+  fi
+}
+
+main

--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -30,7 +30,7 @@ get_ssh_user() {
       $1 = "";
       sub( /^[[:space:]]*/, "" );
       printf "%s|%s\n", host, $0;
-    }' .ssh/config`; do
+    }' /etc/ssh/ssh_config`; do
     local host_regex=${ssh_config%|*}
     local host_user=${ssh_config#*|}
     if [[ "$1" =~ $host_regex ]]; then

--- a/scripts/ssh_session.sh
+++ b/scripts/ssh_session.sh
@@ -31,7 +31,7 @@ parse_ssh_config() {
     }' $1`; do
     local host_regex=${ssh_config%|*}
     local host_user=${ssh_config#*|}
-    if [[ "$2" == $host_regex ]]; then
+    if [ "$2" == "$host_regex" ]; then
       ssh_user_found=$host_user
       break
     fi
@@ -111,7 +111,7 @@ main() {
   user=$(get_info whoami)
 
   # Only show port info if ssh session connected (no localhost) and option enabled
-  if $(ssh_connected) && [[ $show_ssh_session_port == "true" ]] ; then
+  if $(ssh_connected) && [ "$show_ssh_session_port" == "true" ] ; then
     port=$(get_info port)
     echo $user@$hostname:$port
   else


### PR DESCRIPTION
This plugin shows ssh connection information of active TMUX pane in the status line.

The default format is:
`user@hostname`

It can be configured to show also the connection port via `@dracula-show-ssh-session-port true`
`user@hostname:port`

When no ssh session is active it will show current user and hostname of local machine i.e: `whoami@hostname`

Color can be configured as any other dracula plugin. Default background is green and foregraund dark_gray.

Useful when user@hostname is not present in the terminal prompt or if working inside a terminal application e.g; vim, htop, etc.

Plugin appearence:
![image](https://github.com/dracula/tmux/assets/71462682/cedac170-7738-430c-a960-5550fd4d2444)