### PR TITLE
Add hostname option for show_left_icon

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -54,6 +54,8 @@ main()
       left_icon="#S";;
     window)
       left_icon="#W";;
+    hostname)
+      left_icon="#H";;
     *)
       left_icon=$show_left_icon;;
   esac


### PR DESCRIPTION
I saw this has been discussed before, and rejected for bloat. This simply adds another configuration to the left icon to make it more useful than the default smiley face. 

The primary motivation for this is I have multiple boxes I tmux to, and I'd like to use the dracula theme everywhere and still be able to distinguish between which box I'm connected to.