### PR TITLE
Update network.sh to not cut off SSIDs starting with `^`

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -18,8 +18,8 @@ get_ssid()
       ;;
 
     Darwin)
-      if /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2 | sed 's/ ^*//g' &> /dev/null; then
-        echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)" | sed 's/ ^*//g'
+      if /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
+        echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
       else
         echo 'Ethernet'
       fi


### PR DESCRIPTION
My SSID is `^_^`. I noticed that gets cutt of to `_^` in the status bar. 

I think the original regex (introduced here: https://github.com/dracula/tmux/pull/39) is just wrong, maybe the "start of line" indicator is in the wrong place? Anyway, this new regex will fix that.

The plain SSID without the regex replacement:
```
❯ echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)"
 ^_^
```

(note the extra space it's supposed to remove)

Before:
```
❯ echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)" | sed 's/ ^*//g'
_^
```

After: 

```
❯ echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
^_^
```

`sed 's/^ *//g'` will also work, but I like the explicitness of `[[:blank:]]`.