### PR TITLE
MPD Plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context, synchronize-panes
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, mpc, spotify-tui, kubernetes-context, synchronize-panes
 
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
 - Info if the Panes are synchronized
 - Spotify playback (needs the tool spotify-tui installed)
+- Music Player Daemon status (needs the tool mpc installed)
 - Current kubernetes context
 - Countdown to tmux-continuum save
 - Current working directory of tmux pane

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -214,7 +214,7 @@ main()
       script="#($current_dir/attached_clients.sh)"
 
     elif [ $plugin = "mpc" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-mpc-colors" "green dark_gray")
       script="#($current_dir/mpc.sh)"
 
     elif [ $plugin = "spotify-tui" ]; then

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -148,7 +148,7 @@ main()
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")
       tmux set-option -g status-right-length 250
       script="#($current_dir/cwd.sh)"
-    
+
     elif [ $plugin = "fossil" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-fossil-colors" "green dark_gray")
       tmux set-option -g status-right-length 250
@@ -212,6 +212,10 @@ main()
     elif [ $plugin = "attached-clients" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-attached-clients-colors" "cyan dark_gray")
       script="#($current_dir/attached_clients.sh)"
+
+    elif [ $plugin = "mpc" ]; then
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")
+      script="#($current_dir/mpc.sh)"
 
     elif [ $plugin = "spotify-tui" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")

--- a/scripts/mpc.sh
+++ b/scripts/mpc.sh
@@ -15,8 +15,8 @@ main()
     exit 1
   fi
 
-  # FORMAT=$(get_tmux_option "@dracula-spotify-tui-format" "%f %s %t - %a")
-  mpc_playback=$(mpc current)
+  FORMAT=$(get_tmux_option "@dracula-mpc-format" "%title% - %artist%")
+  mpc_playback=$(mpc current -f "${FORMAT}")
   echo ${mpc_playback}
 
 }

--- a/scripts/mpc.sh
+++ b/scripts/mpc.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+main()
+{
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+
+  if ! command -v mpc &> /dev/null
+  then
+    exit 1
+  fi
+
+  # FORMAT=$(get_tmux_option "@dracula-spotify-tui-format" "%f %s %t - %a")
+  mpc_playback=$(mpc current)
+  echo ${mpc_playback}
+
+}
+
+# run the main driver
+main


### PR DESCRIPTION
- feat: Added mpc plugin
- feat: Added MPC documentation
- feat: Added tmux.conf customizations

## Pull Request

Introduces a MPC Plugin for this theme.
Closes #238.

## Description of Changes

PR introduces a mpc plugin, which can be enabled by the user using the `mpc` keyword in the `@dracula-plugins` variable.
This plugin shows the current state of MPD in the tabline.
The plugin supports the plugin customizations including

- Colors (@dracula-mpc-colors)
- Display Format (@dracula-mpc-format). The reference for which is [here](https://www.musicpd.org/doc/mpc/html/).

For the above functionality. 2 files have been edited

- `scripts/mpc.sh`
- `scripts/dracula.sh`

This plugin requires the `mpc` tool to be installed.

All of the above info is also updated in

- `README.md`
- `INSTALL.md`

## Testing

Both the customizations have been tested on my system and is in working condition.
Tested on a Arch Linux system with latest `mpc`, `tmux`.
