### PR TITLE
[FIX] '~' escaping in `cwd.sh`

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -16,7 +16,7 @@ main() {
   path=$(getPaneDir)
 
   # change '/home/user' to '~'
-  cwd="${path/"$HOME"/'~'}"
+  cwd="${path/"$HOME"/~}"
 
   echo "$cwd"
 }


### PR DESCRIPTION
I modified to remove single quotes because single quotes put between double quotes should be rendered as an actual character.

If this was the expected behavior, please close this PR 👍 