### PR TITLE
Fix: Avoid potential delay in calc of RAM (darwin)

### DIFF
--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -19,7 +19,10 @@ get_ratio()
     Darwin)
       # Get used memory blocks with vm_stat, multiply by page size to get size in bytes, then convert to MiB
       used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2) * pagesize / 1048576}')
-      total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
+      # System Profiler performs an activation lock check, which can result in
+      # time outs or a lagged response. (~10 seconds)
+      # total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
+      total_mem=$(sysctl -n hw.memsize | awk '{print $0/1024/1024/1024 " GB"}')
       if ((used_mem < 1024 )); then
         echo "${used_mem}MB/$total_mem"
       else


### PR DESCRIPTION
The system_profiler command used to determine the total memory on darwin systems performs an "Activation Lock" check. This can produce a delay in returning total memory. I began experiencing delays of around 10 seconds.

Switching from system_profiler to sysctl to calculate total memory bypasses the "Activation Lock" check / timeout scenario.

Results of "time" command using system_profiler:

> system_profiler SPHardwareDataType  0.17s user 0.23s system 3% cpu 10.165 total grep -a "Memory:"  0.00s user 0.00s system 0% cpu 10.164 total awk '{print $2 $3}'  0.00s user 0.00s system 0% cpu 10.163 total

Results of "time" command using sysctl:
> sysctl -n hw.memsize  0.00s user 0.00s system 83% cpu 0.004 total awk '{print $0/1024/1024/1024 " GB"}'  0.00s user 0.00s system 86% cpu 0.004 total