### PR TITLE
Fix multi word fixed location

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -238,7 +238,7 @@ main()
 
     elif [ $plugin = "weather" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
-      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location $fixed_location)"
+      script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location '$fixed_location')"
 
     elif [ $plugin = "time" ]; then
       IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-time-colors" "dark_purple white")

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -23,7 +23,7 @@ fetch_weather_information()
 {
   display_weather=$1
   # it gets the weather condition textual name (%C), and the temperature (%t)
-  curl -sL wttr.in/$fixedlocation\?format="%C+%t$display_weather"
+  curl -sL wttr.in/${fixedlocation// /%20}\?format="%C+%t$display_weather"
 }
 
 #get weather display

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -20,7 +20,7 @@ main()
 
   if [ "$(expr ${TIME_LAST} + ${RUN_EACH})" -lt "${TIME_NOW}" ]; then
     # Run weather script here
-    $current_dir/weather.sh $fahrenheit $location $fixedlocation > "${DATAFILE}"
+    $current_dir/weather.sh $fahrenheit $location "$fixedlocation" > "${DATAFILE}"
     echo "${TIME_NOW}" > "${LAST_EXEC_FILE}"
   fi
 


### PR DESCRIPTION
If you set the @dracula-fixed-location to "San Diego, California" it ends up looking at "San" which is somewhere in South Korea. This occurs for any fixed-location that has a space. Something like "Portland, Oregon" can be modified to "Portland,Oregon" and still work but we can't remove the space from "San Diego". The reason that spaces in the fixed location break the backend request is that dracula.sh loses everything after the space.

Q: Why does the fixed-location end up as "San"?
A: In dracula.sh the fixed-location is not wrapped in quotes when embedded in the status-right string.

A: In weather_wrapper.sh the call to weather.sh does not wrap the fixed-location argument with quotes.

Q: When these are fixed why do we get a broken link? A: Since we are calling a web service using a url, we need to escape the spaces by changing them to %20