### PR TITLE
add network bandwidth support for macOS

### DIFF
--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -85,7 +85,7 @@ bandwidth_to_unit() {
 
   local result="0.00"
   if (($1 != 0)); then
-    result="$(bc <<<"scale=2; $1 / $size")"
+    result="$(awk -v a="$1" -v b="$size" 'BEGIN { printf "%.2f\n", a / b }' </dev/null)"
   fi
 
   echo "$result ${SIZE[$size]}"
@@ -101,12 +101,6 @@ main() {
 
   if [[ -z $interval_update ]]; then
     interval_update=0
-  fi
-
-  if ! command -v bc &> /dev/null
-  then
-    echo "command bc could not be found!"
-    exit 1
   fi
 
   while true; do

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -37,23 +37,38 @@ interface_get() {
   echo "$name"
 }
 
-# interface_bytes give interface name and signal tx/rx return Bytes
+# interface_bytes give an interface name and return both tx/rx Bytes, separated by whitespace (upload first)
 interface_bytes() {
-  cat "/sys/class/net/$1/statistics/$2_bytes"
+  case "$(uname -s)" in
+  Linux)
+    upload=$(cat "/sys/class/net/$1/statistics/tx_bytes")
+    download=$(cat "/sys/class/net/$1/statistics/rx_bytes")
+
+    echo "$upload $download"
+    ;;
+  Darwin)
+    # column 7 is Ibytes (in bytes, rx, download) and column 10 is Obytes (out bytes, tx, upload)
+    netstat -nbI "$1" | tail -n1 | awk '{print $10 " " $7}'
+    ;;
+  esac
 }
 
 # get_bandwidth return the number of bytes exchanged for tx and rx
 get_bandwidth() {
-  upload="$(interface_bytes "$1" "tx")"
-  download="$(interface_bytes "$1" "rx")"
+  local upload=0
+  local download=0
 
-  #wait the interval for Wait for interval to calculate the difference
+  IFS=' ' read -r upload download <<< "$(interface_bytes "$1")"
+
+  # wait for interval to calculate the difference
   sleep "$INTERVAL"
 
-  upload="$(bc <<<"$(interface_bytes "$1" "tx") - $upload")"
-  download="$(bc <<<"$(interface_bytes "$1" "rx") - $download")"
+  IFS=' ' read -r new_upload new_download <<< "$(interface_bytes "$1")"
 
-  #set to 0 by default useful for non-existent interface
+  upload=$(( $new_upload - $upload ))
+  download=$(( $new_download - $download ))
+
+  # set to 0 by default
   echo "${upload:-0} ${download:-0}"
 }
 

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -26,6 +26,11 @@ interface_get() {
         name="$(ip -o route get 192.168.0.0 | awk '{print $5}')"
       fi
       ;;
+    Darwin)
+      if type route >/dev/null; then
+        name="$(route -n get 192.168.0.0 2>/dev/null | awk '/interface: / {print $2}')"
+      fi
+      ;;
     esac
   fi
 


### PR DESCRIPTION
So I went to enable network-bandwidth (on a mac) and noticed this wasn't supported yet, but it was only *after* getting some custom changes working locally that I even thought to check if there was already a PR for it haha.

I see #113 exists already, but it looks like the person who made that PR just got busy with work and hasn't had time to address all the feedback and resolve the conflicts, and progress seems to have stalled on that several years ago - so I really hope I'm not stepping on any toes by making a separate PR for the same feature, but I'd really love to get this merged into the repo so that I don't need to run a modified version of this repo and manually keep it in sync with my local changes when I update to newer versions.

please let me know if there's anything I should change, happy to ^.^
(I figure you'll probably want me to squash the commits, but I'll leave them as-is for now, for convenience)

and some notes to hopefully make reviewing this a bit easier:

- Uses `route` instead of `ip` to get the interface name on Darwin Architectures, which is installed by default on macOS.
- Uses basically the same approach as in #113 with `netstat` to get the tx and rx bytes, except instead of calling netstat twice, we can just do it once and return both values at the same time.
- Updated the `interface_bytes` fn to no longer require a second argument ($2 which would always either be "tx" or "rx"), so instead now it just gets the interface name from $1 (the first argument) and returns BOTH the tx and rx bytes for that interface, in the format: "TX_Bytes RX_Bytes" where the upload (tx) bytes are listed first, as is the convention elsewhere, and then a whitespace character followed by the download (rx) bytes. This lets us reduce the number of calls to `interface_bytes` per interval from 4 to 2 while also making the code in `get_bandwidth` a bit simpler and easier to read.
- And the last commit is not really required to support network-bandwidth on macOS (so I can revert if you don't think this is a good change), but I also switched out the line using `bc` to use `awk` for floating point math, the "%.2f" limits the output of printf to two decimal places. I believe it should be reasonable to expect awk to be installed already on most OS's and the repo's existing patterns seem to agree but please lmk if that's not a sound assumption.
