### PR TITLE
feat: Added playerctl plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To enable plugins set up the `@dracula-plugins` option in you `.tmux.conf` file,
 The order that you define the plugins will be the order on the status bar left to right.
 
 ```bash
-# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, ssh-session, attached-clients, network-vpn, weather, time, mpc, spotify-tui, kubernetes-context, synchronize-panes
+# available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, tmux-ram-usage, network, network-bandwidth, network-ping, ssh-session, attached-clients, network-vpn, weather, time, mpc, spotify-tui, playerctl, kubernetes-context, synchronize-panes
 set -g @dracula-plugins "cpu-usage gpu-usage ram-usage"
 ```
 
@@ -94,7 +94,7 @@ set -g @dracula-refresh-rate 5
 Switch the left smiley icon
 
 ```bash
-# it can accept `hostname` (full hostname), `session`, `shortname` (short name), `smiley`, `window`, or any character. 
+# it can accept `hostname` (full hostname), `session`, `shortname` (short name), `smiley`, `window`, or any character.
 set -g @dracula-show-left-icon session
 ```
 
@@ -373,4 +373,12 @@ Show if the last save was performed less than 60 seconds ago (default threshold 
 
 ```bash
 set -g @dracula-continuum-time-threshold 60
+```
+
+#### Playerctl format
+
+Set the playerctl metadata format
+
+```
+set -g @dracula-playerctl-format "►  {{ artist }} - {{ title }}"
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - Info if the Panes are synchronized
 - Spotify playback (needs the tool spotify-tui installed)
 - Music Player Daemon status (needs the tool mpc installed)
+- Playerctl, get current track metadata
 - Current kubernetes context
 - Countdown to tmux-continuum save
 - Current working directory of tmux pane

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -224,6 +224,10 @@ main()
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")
       script="#($current_dir/spotify-tui.sh)"
 
+    elif [ $plugin = "playerctl" ]; then
+      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-playerctl-colors" "green dark_gray")
+      script="#($current_dir/playerctl.sh)"
+
     elif [ $plugin = "kubernetes-context" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")
       script="#($current_dir/kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_kubernetes_context_label)"

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+main()
+{
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+
+  if ! command -v playerctl &> /dev/null
+  then
+    exit 1
+  fi
+
+  FORMAT=$(get_tmux_option "@dracula-playerctl-format" "Now playing: {{ artist }} - {{ album }} - {{ title }}")
+  playerctl_playback=$(playerctl metadata --format "${FORMAT}")
+  echo ${playerctl_playback}
+
+}
+
+# run the main driver
+main


### PR DESCRIPTION
Added a plugin for the playerctl cli tool.
https://github.com/altdesktop/playerctl

This tool can control multiple media players, I just implemented the `playerctl metadata` command with a configurable format.
https://github.com/altdesktop/playerctl#printing-properties-and-metadata

![image](https://github.com/dracula/tmux/assets/3588373/c8281166-7ff3-4efd-83e3-ccbd4669a449)
