### PR TITLE
Change how Wi-Fi network info is received on Mac

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -18,8 +18,8 @@ get_ssid()
       ;;
 
     Darwin)
-      if /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
-        echo "$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I | grep -E ' SSID' | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
+      if networksetup -getairportnetwork en0 | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
+        echo "$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
       else
         echo 'Ethernet'
       fi


### PR DESCRIPTION
The `airport` command is now deprecated on macOS 14.4+. Changing it to use the `networksetup` command to get this information instead based on suggestions in #256.