### PR TITLE
Difference between !$show_day_month and $show_military (show clock only)

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -252,7 +252,7 @@ main()
         if $show_day_month && $show_military ; then # military time and dd/mm
           script="%a %d/%m %R ${timezone} "
         elif $show_military; then # only military time
-          script="%a %m/%d %R ${timezone} "
+          script="%R ${timezone} "
         elif $show_day_month; then # only dd/mm
           script="%a %d/%m %I:%M %p ${timezone} "
         else


### PR DESCRIPTION
When `$show_day_month` is false, but `$show_military` is true, we can render a clock with date information.

Previously, `$show_day_month` had no effect on the output.