### PR TITLE
Use fixed width for network bandwidth to avoid jumps

### DIFF
--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -112,7 +112,7 @@ main() {
     IFS=" " read -ra bandwidth <<<"$(get_bandwidth "$network_name")"
 
     if [[ $show_interface == "true" ]]; then echo -n "[$network_name] "; fi
-    echo "↓ $(bandwidth_to_unit "${bandwidth[$DOWNLOAD]}") • ↑ $(bandwidth_to_unit "${bandwidth[$UPLOAD]}")"
+    printf "↓ %6s %-4s • ↑ %6s %-4s\n" $(bandwidth_to_unit "${bandwidth[$DOWNLOAD]}") $(bandwidth_to_unit "${bandwidth[$UPLOAD]}")
 
     ((counter = counter - 1))
     sleep "$interval_update"


### PR DESCRIPTION
Use fixed width for network bandwidth to avoid jumps.