### PR TITLE
Fix MacOS RAM usage calculation in ram_info.sh

### DIFF
--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -18,7 +18,7 @@ get_ratio()
 
     Darwin)
       # Get used memory blocks with vm_stat, multiply by page size to get size in bytes, then convert to MiB
-      used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2) * pagesize / 1048576}')
+      used_mem=$(vm_stat | grep ' active\|wired\|compressor\|speculative' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2+$3+$5) * pagesize / 1048576}')
       # System Profiler performs an activation lock check, which can result in
       # time outs or a lagged response. (~10 seconds)
       # total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')


### PR DESCRIPTION
This PR addresses the incorrect RAM usage calculation for MacOS in `ram_info.sh`. Previously, the calculation for `used_mem` only took into account the `active` and `wired` memory. This leaves out key components of used memory, leading to potentially inaccurate results.

Changes in this PR involve modifying the calculation to include `compressor` and `speculative` memory. This change yields a more complete calculation of used memory. 