### PR TITLE
Updated playerctl script to allow scrolling text

### DIFF
--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -34,7 +34,6 @@ main() {
   playerctl_playback=$(playerctl metadata --format "${FORMAT}")
   playerctl_playback="${playerctl_playback} "
 
-  # Determine the length of the terminal window (not implemented here)
   # Adjust width of string
   terminal_width=25
 
@@ -45,13 +44,11 @@ main() {
   scrolling_text=""
 
   for ((start = 0; start <= len; start++)); do
-    # Slice the string starting from 'start' index and display 'terminal_width' characters
     scrolling_text=$(slice_loop "$playerctl_playback" "$start" "$terminal_width")
     echo -ne "\r"
     echo "$scrolling_text "
     echo -ne "\r"
 
-    # Sleep for RATE seconds before updating the display (adjust RATE as needed)
     sleep 0.08
   done
 

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -35,7 +35,7 @@ main() {
   playerctl_playback="${playerctl_playback} "
 
   # Determine the length of the terminal window (not implemented here)
-  # Adjust 'terminal_width' based on your actual terminal width
+  # Adjust width of string
   terminal_width=25
 
   # Initial start point for scrolling
@@ -44,21 +44,20 @@ main() {
 
   scrolling_text=""
 
-  for ((i = 0; i <= len; i++)); do
+  for ((start = 0; start <= len; start++)); do
     # Slice the string starting from 'start' index and display 'terminal_width' characters
     scrolling_text=$(slice_loop "$playerctl_playback" "$start" "$terminal_width")
     echo -ne "\r"
-    echo "$scrolling_text"
+    echo "$scrolling_text "
     echo -ne "\r"
-
-    # Check if the beginning of the original string reappears at the start of the visible area
-
-    # Update the start index for the next iteration
-    ((start++))
 
     # Sleep for RATE seconds before updating the display (adjust RATE as needed)
     sleep 0.08
   done
+
+  echo -ne "\r"
+  echo "$scrolling_text "
+  echo -ne "\r"
 }
 
 # run the main driver

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -2,23 +2,71 @@
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=en_US.UTF-8
 
-current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $current_dir/utils.sh
 
-main()
-{
+function slice_loop() {
+  local str="$1"
+  local start="$2"
+  local how_many="$3"
+  local len=${#str}
+
+  local result=""
+
+  for ((i = 0; i < how_many; i++)); do
+    local index=$(((start + i) % len))
+    local char="${str:index:1}"
+    result="$result$char"
+  done
+
+  echo "$result"
+}
+
+function update_playerctl_playback() {
+  FORMAT=$(get_tmux_option "@dracula-playerctl-format" "Now playing: {{ artist }} - {{ album }} - {{ title }}")
+
+  playerctl_playback=$(playerctl metadata --format "${FORMAT}")
+  msg="${playerctl_playback}"
+
+  len=${#msg}
+}
+
+main() {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
 
-  if ! command -v playerctl &> /dev/null
-  then
+  if ! command -v playerctl &>/dev/null; then
     exit 1
   fi
 
-  FORMAT=$(get_tmux_option "@dracula-playerctl-format" "Now playing: {{ artist }} - {{ album }} - {{ title }}")
-  playerctl_playback=$(playerctl metadata --format "${FORMAT}")
-  echo ${playerctl_playback}
+  update_playerctl_playback
+  window_size=25 # Number of characters to display at once
+  begin=0
 
+  while true; do
+    slice=$(slice_loop "$msg" $begin $window_size)
+    echo -ne " \r"
+    echo -n "$slice"
+    echo -ne "\r"
+    sleep 0.1
+
+    ((begin++))
+
+    # Check if playerctl_playback has changed
+    updated_msg=$(playerctl metadata --format "${FORMAT}")
+    updated_msg="$updated_msg "
+
+    if [ "$updated_msg" != "$playerctl_playback" ]; then
+      playerctl_playback="$updated_msg"
+
+      msg="$playerctl_playback"
+
+      len=${#msg}
+
+      begin=0
+      sleep 1
+    fi
+  done
 }
 
 # run the main driver

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -44,7 +44,20 @@ main() {
   begin=0
 
   while true; do
-    slice=$(slice_loop "$msg" $begin $window_size)
+    # Check if playerctl metadata command is available
+    if ! command -v playerctl metadata &>/dev/null; then
+      echo ""
+      exit 1
+    fi
+
+    # Slice the message to display
+    if [ "$len" -le "$window_size" ]; then
+      # If msg length is smaller than window_size, display the entire msg
+      slice="$msg"
+    else
+      slice=$(slice_loop "$msg" $begin $window_size)
+    fi
+
     echo -ne " \r"
     echo -n "$slice"
     echo -ne "\r"
@@ -58,15 +71,13 @@ main() {
 
     if [ "$updated_msg" != "$playerctl_playback" ]; then
       playerctl_playback="$updated_msg"
-
       msg="$playerctl_playback"
-
       len=${#msg}
-
       begin=0
       sleep 1
     fi
   done
+
 }
 
 # run the main driver


### PR DESCRIPTION
Updated playerctl script with a scrolling text based on the character number returned from the `playerctl_playback` variable. Right now the length is hard coded to be 25 but could be extended by updating the api for media controls.

![image](https://github.com/user-attachments/assets/07c4f684-39f4-44c7-9cf4-654c3dc830f7)
