### PR TITLE
allow user to force getting gpu info without asking lspci #272

### DIFF
--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -9,8 +9,14 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-      echo $gpu
+      # use this option for when you know that there is an NVIDIA gpu, but you cant use lspci to determine
+      ignore_lspci=$(get_tmux_option "@dracula-ignore-lspci" false)
+      if [[ "$ignore_lspci" = true ]]; then
+        echo "NVIDIA"
+      else
+        gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+        echo $gpu
+      fi
       ;;
 
     Darwin)

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -9,8 +9,14 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-      echo $gpu
+      # use this option for when you know that there is an NVIDIA gpu, but you cant use lspci to determine
+      ignore_lspci=$(get_tmux_option "@dracula-ignore-lspci" false)
+      if [[ "$ignore_lspci" = true ]]; then
+        echo "NVIDIA"
+      else
+        gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+        echo $gpu
+      fi
       ;;
 
     Darwin)

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -9,8 +9,14 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-      echo $gpu
+      # use this option for when you know that there is an NVIDIA gpu, but you cant use lspci to determine
+      ignore_lspci=$(get_tmux_option "@dracula-ignore-lspci" false)
+      if [[ "$ignore_lspci" = true ]]; then
+        echo "NVIDIA"
+      else
+        gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
+        echo $gpu
+      fi
       ;;
 
     Darwin)


### PR DESCRIPTION
i myself and other people have had issues with lspci not being available or not returning the right values for data to be displayed, despite there being an nvidia gpu and functioning nvidia-smi. this commit adds an optional flag that allows to tell tmux that there is an nvidia gpu, without any checks.

just `set -g @dracula-ignore-lspci true` and it works. this is partially in response to #272