### PR TITLE
feature/ better battery indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - List of windows with the current window highlighted
 - When prefix is enabled, a smiley face turns from green to yellow
 - When charging, 'AC' is displayed
+    - Alternatively show battery level and whether its charging next to percentage by setting:
+    `set -g @dracula-battery-label false`
+    `set -g @dracula-show-battery-status true`
 - If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
 - Info if the Panes are synchronized
 - Spotify playback (needs the tool spotify-tui installed)


### PR DESCRIPTION
in reference to #225 this pull request implements nerdfont icons as battery indicators. it shows how much and whether the pc is charging. additionally the pull request is adding a few extra cases i stumbled upon in macos.

please let me know if my change to the readme is sensible or should be altered to not break the pattern.

special thanks to @sydrawat01 whose code i partially copied to replace my old solution with.