### PR TITLE
feature/ add max len to spotify and fix output when no device available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - When charging, 'AC' is displayed
 - If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
 - Info if the Panes are synchronized
-- Spotify playback (needs the tool spotify-tui installed)
+- Spotify playback (needs the tool spotify-tui installed). max-len can be configured.
 - Music Player Daemon status (needs the tool mpc installed)
 - Playerctl, get current track metadata
 - Current kubernetes context

--- a/scripts/spotify-tui.sh
+++ b/scripts/spotify-tui.sh
@@ -15,10 +15,20 @@ main()
     exit 1
   fi
 
+  if [ "$(spt list --devices)" = "No devices available" ]
+  then
+    echo ""
+    exit 0
+  fi
+
   FORMAT=$(get_tmux_option "@dracula-spotify-tui-format" "%f %s %t - %a")
   spotify_playback=$(spt playback -f "${FORMAT}")
-  echo ${spotify_playback}
-
+  max_len=$(get_tmux_option "@dracula-spotify-tui-max-len" 0)
+  if [[ $max_len -ne 0 ]] ; then
+    echo ${spotify_playback} | head -c $max_len
+  else
+    echo ${spotify_playback}
+  fi
 }
 
 # run the main driver


### PR DESCRIPTION
in reference to issue #192 this adds a flag to set the maximum length that spotify is allowed to display.
additionally this fixes there being weird output when spt signals that no device is available.

in #192 it is mentioned that kubernetes has a similar issue, so i think that this solution could likely be used there too, but i dont use kubernetes, so i cant test it.