### PR TITLE
feature/ MacOS show vpn name and tailscale exit node if active

### DIFF
--- a/scripts/network_vpn.sh
+++ b/scripts/network_vpn.sh
@@ -5,16 +5,43 @@ export LC_ALL=en_US.UTF-8
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $current_dir/utils.sh
 
+
+
 vpn_function() {
   case $(uname -s) in
   Linux)
+
+    verbose=$(get_tmux_option "@dracula-network-vpn-verbose" false)
+
     #Show IP of tun0 if connected
     vpn=$(ip -o -4 addr show dev tun0 | awk '{print $4}' | cut -d/ -f1)
 
+    which -s tailscale > /dev/null
+    tailscale_installed=$?
+
     if [[ $vpn =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
       echo $vpn
+    elif [ $tailscale_installed ]; then
+      # if tailscale is installed
+      #
+      # https://www.reddit.com/r/Tailscale/comments/18dirro/is_there_a_way_i_can_tell_which_exit_node_i_am/
+      node=$(tailscale status --peers --json | jq '.ExitNodeStatus')
+      if [[ -z $node ]] || [[ "$node"  == 'null' ]]; then
+        # no tailscale exit node, no output, since trafic isnt actually rerouted
+        echo ""
+      else
+        exitnode=$(tailscale status | grep "; exit node" | awk '{print $2}')
+
+        if $verbose; then
+          vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "󰌘 ")
+          echo "$vpn_label$exitnode"
+        else
+          vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "Tailscale")
+          echo "$vpn_label"
+        fi
+      fi
     else
-      echo "NO VPN"
+      echo ""
     fi
   ;;
 
@@ -45,18 +72,22 @@ vpn_function() {
         exitnode=$(tailscale status | grep "; exit node" | cut -w -f 2)
 
         if $verbose; then
-          echo "󰌘 $exitnode"
+          vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "󰌘 ")
+          echo "$vpn_label$exitnode"
         else
-          echo "Tailscale"
+          vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "Tailscale")
+          echo "$vpn_label"
         fi
       fi
 
     else
       if $verbose; then
         vpn_name=$(echo $is_not_tailscale | sed "s/.*\"\(.*\)\".*/\1/g")
-        echo "󰌘 $vpn_name"
+        vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "󰌘 ")
+        echo "$vpn_label$vpn_name"
       else
-        echo "VPN"
+        vpn_label=$(get_tmux_option "@dracula-network-vpn-label" "VPN")
+        echo "$vpn_label"
       fi
     fi
     ;;

--- a/scripts/network_vpn.sh
+++ b/scripts/network_vpn.sh
@@ -25,7 +25,7 @@ vpn_function() {
       # if tailscale is installed
       #
       # https://www.reddit.com/r/Tailscale/comments/18dirro/is_there_a_way_i_can_tell_which_exit_node_i_am/
-      node=$(tailscale status --peers --json | jq '.ExitNodeStatus')
+      node=$(tailscale status  | grep "; exit node")
       if [[ -z $node ]] || [[ "$node"  == 'null' ]]; then
         # no tailscale exit node, no output, since trafic isnt actually rerouted
         echo ""
@@ -64,7 +64,7 @@ vpn_function() {
       # always show as connected for some reason.
       #
       # https://www.reddit.com/r/Tailscale/comments/18dirro/is_there_a_way_i_can_tell_which_exit_node_i_am/
-      node=$(tailscale status --peers --json | jq '.ExitNodeStatus')
+      node=$(tailscale status  | grep "; exit node")
       if [[ -z $node ]] || [[ "$node"  == 'null' ]]; then
         # no tailscale exit node, no output, since trafic isnt actually rerouted
         echo ""


### PR DESCRIPTION
on macos and linux the vpn option now is able to show the name of the vpn if in verbose mode or `VPN` if verbose is off.
if a tailscale exit-node is used, it shows its name in verbose, or `Tailscale` if verbose is off.

scutil did some funky stuff for me, so i had to filter out the asterisks 😅

new options for the network-vpn plugin
`@dracula-network-vpn-label` 
this option is what is displayed when verbose is false.
if verbose is true, this label is the prefix to the name of the vpn/ exitnode.
`@dracula-network-vpn-verbose`
whether to display the vpn/ exitnode name
