### PR TITLE
better battery indication for charging from AC

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -112,17 +112,17 @@ battery_status()
     charging|Charging)
       # charging from AC
       declare -A battery_labels=(
-        [0]="󰂎"
-        [10]="󰁺"
-        [20]="󰁻"
-        [30]="󰁼"
-        [40]="󰁽"
-        [50]="󰁾"
-        [60]="󰁿"
-        [70]="󰂀"
-        [80]="󰂁"
-        [90]="󰂂"
-        [100]="󰁹"
+        [0]="󰢟"
+        [10]="󰢜"
+        [20]="󰂆"
+        [30]="󰂇"
+        [40]="󰂈"
+        [50]="󰢝"
+        [60]="󰂉"
+        [70]="󰢞"
+        [80]="󰂊"
+        [90]="󰂋"
+        [100]="󰂅"
       )
       echo "${battery_labels[$((bat_perc/10*10))]:-󰂃}"
       ;;
@@ -131,7 +131,7 @@ battery_status()
       echo ''
       ;;
     finishingcharge)
-      echo '󰁹'
+      echo '󰂅'
       ;;
     *)
       # something wrong...
@@ -175,4 +175,3 @@ main()
 
 #run main driver program
 main
-


### PR DESCRIPTION
Follow-up to https://github.com/dracula/tmux/pull/276.

However, the icons for charging from AC have been replaced with a single-symbol icon instead of two symbols for better visibility.

![image](https://github.com/user-attachments/assets/e4f27117-583d-425f-98d6-d78b377e6ce2)
