### PR TITLE
fix show battery percent sign on linux

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -41,7 +41,7 @@ battery_percent()
   case $(uname -s) in
     Linux)
       percent=$(linux_acpi percent)
-      [ -n "$percent" ] && echo " $percent"
+      [ -n "$percent" ] && echo "$percent%"
       ;;
 
     Darwin)
@@ -175,4 +175,3 @@ main()
 
 #run main driver program
 main
-


### PR DESCRIPTION
Before:

![before](https://github.com/user-attachments/assets/a26df3e4-5245-4c72-a1ad-3ab961dbf72f)

After:

![image](https://github.com/user-attachments/assets/5c818dea-5e65-48a5-a1c0-63f2bd38f015)
