### PR TITLE
Add new kubernetes option to just show the context name

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -9,6 +9,7 @@ main()
 {
   # set configuration option variables
   show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
+  show_only_kubernetes_context=$(get_tmux_option "@dracula-show-only-kubernetes-context" "")
   eks_hide_arn=$(get_tmux_option "@dracula-kubernetes-eks-hide-arn" false)
   eks_extract_account=$(get_tmux_option "@dracula-kubernetes-eks-extract-account" false)
   hide_kubernetes_user=$(get_tmux_option "@dracula-kubernetes-hide-user" false)
@@ -231,7 +232,7 @@ main()
 
     elif [ $plugin = "kubernetes-context" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")
-      script="#($current_dir/kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_kubernetes_context_label)"
+      script="#($current_dir/kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_only_kubernetes_context $show_kubernetes_context_label)"
 
     elif [ $plugin = "terraform" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-terraform-colors" "light_purple dark_gray")

--- a/scripts/kubernetes_context.sh
+++ b/scripts/kubernetes_context.sh
@@ -5,7 +5,8 @@ export LC_ALL=en_US.UTF-8
 hide_arn_from_cluster=$1
 extract_account=$2
 hide_user=$3
-label=$4
+just_current_context=$4
+label=$5
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
@@ -34,6 +35,19 @@ main()
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   OUTPUT_STRING=""
+
+  if [ "$just_current_context" = "true" ]
+  then
+    echo "$current_context"
+  else
+    getFullMessage
+  fi
+
+  sleep $RATE
+}
+
+getFullMessage()
+{
   if [ ! -z "$current_account_id" ]
   then
       OUTPUT_STRING="${current_account_id}/"
@@ -65,8 +79,6 @@ main()
   else
     echo "${label} ${OUTPUT_STRING}"
   fi
-
-  sleep $RATE
 }
 
 # run the main driver


### PR DESCRIPTION
When using the kubernetes plugin the existing options create very extensive labels and hard it's to differenciate between them if you have several environments in the same cloud account.
Therefor the kubernetes config context name might be the best option to differentiate between them. 