### PR TITLE
Feature/better gpu

### DIFF
--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -49,7 +49,7 @@ main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-  gpu_label=$(get_tmux_option "@dracula-gpu-usage-label" "GPU")
+  gpu_label=$(get_tmux_option "@dracula-gpu-power-label" "GPU")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
   sleep $RATE

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -20,7 +20,10 @@ get_platform()
       ;;
 
     Darwin)
-      # TODO - Darwin/Mac compatability
+      # WARNING: for this to work the powermetrics command needs to be run without password
+      #   add this to the sudoers file, replacing the username and omitting the quotes.
+      #   be mindful of the tabs: "username		ALL = (root) NOPASSWD: /usr/bin/powermetrics"
+      echo "apple"
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)
@@ -28,13 +31,14 @@ get_platform()
       ;;
   esac
 }
-
 get_gpu()
 {
   gpu=$(get_platform)
   if [[ "$gpu" == NVIDIA ]]; then
     usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%dW/%dW\n", draw, max) }')
 
+  elif [[ "$gpu" == apple ]]; then
+    usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'GPU Power' | sed 's/GPU Power: \(.*\) \(.*\)/\1\2/g')"
   else
     usage='unknown'
   fi

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -13,12 +13,16 @@ get_platform()
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
         echo $gpu_label
-      elif type -a nvidia-smi >> /dev/null; then
-        # if nvidia-smi is installed, its highly likely for the gpu to be nvidia, so stop checking
-        echo "NVIDIA"
       else
+        # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-        echo $gpu
+        if [[ -n $gpu ]]; then
+          # if a gpu is detected, return it
+          echo $gpu
+        elif type -a nvidia-smi >> /dev/null; then
+          # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
+          echo "NVIDIA"
+        fi
       fi
       ;;
 

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -9,9 +9,12 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      # use this option for when you know that there is an NVIDIA gpu, but you cant use lspci to determine
-      ignore_lspci=$(get_tmux_option "@dracula-ignore-lspci" false)
-      if [[ "$ignore_lspci" = true ]]; then
+      # use this option for when your gpu isn't detected
+      gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
+      if [[ "$gpu_label" != false ]]; then
+        echo $gpu_label
+      elif type -a nvidia-smi >> /dev/null; then
+        # if nvidia-smi is installed, its highly likely for the gpu to be nvidia, so stop checking
         echo "NVIDIA"
       else
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
@@ -34,8 +37,13 @@ get_platform()
 get_gpu()
 {
   gpu=$(get_platform)
+  gpu_power_percent=$(get_tmux_option "@dracula-gpu-power-percent" false)
   if [[ "$gpu" == NVIDIA ]]; then
-    usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%dW/%dW\n", draw, max) }')
+    if $gpu_power_percent; then
+      usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%d%%\n", draw / max * 100) }')
+  else
+      usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%dW/%dW\n", draw, max) }')
+    fi
 
   elif [[ "$gpu" == apple ]]; then
     usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'GPU Power' | sed 's/GPU Power: \(.*\) \(.*\)/\1\2/g')"

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -44,7 +44,7 @@ main()
 {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
-  gpu_label=$(get_tmux_option "@dracula-gpu-usage-label" "VRAM")
+  gpu_label=$(get_tmux_option "@dracula-gpu-vram-label" "VRAM")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
   sleep $RATE

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -13,12 +13,16 @@ get_platform()
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
         echo $gpu_label
-      elif type -a nvidia-smi >> /dev/null; then
-        # if nvidia-smi is installed, its highly likely for the gpu to be nvidia, so stop checking
-        echo "NVIDIA"
       else
+        # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-        echo $gpu
+        if [[ -n $gpu ]]; then
+          # if a gpu is detected, return it
+          echo $gpu
+        elif type -a nvidia-smi >> /dev/null; then
+          # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
+          echo "NVIDIA"
+        fi
       fi
       ;;
 

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -39,15 +39,18 @@ get_gpu()
   if [[ "$gpu" == NVIDIA ]]; then
     if $gpu_vram_percent; then
       usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk '{ used += $0; total +=$2 } END { printf("%d%%\n", used / total * 100 ) }')
+    normalize_percent_len $usage
+    exit 0
     else
       # to add finer grained info
-      # usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk '{ used += $0; total +=$2 } END { printf("%.1fGB/%dGB\n", used / 1024, total / 1024) }')
-      usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk '{ used += $0; total +=$2 } END { printf("%dGB/%dGB\n", used / 1024, total / 1024) }')
+      used_accuracy=$(get_tmux_option "@dracula-gpu-vram-used-accuracy" "d")
+      total_accuracy=$(get_tmux_option "@dracula-gpu-vram-total-accuracy" "d")
+      usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk "{ used += \$0; total +=\$2 } END { printf(\"%${used_accuracy}GB/%${total_accuracy}GB\n\", used / 1024, total / 1024) }")
     fi
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  echo $usage
 }
 
 main()

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -13,12 +13,16 @@ get_platform()
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
         echo $gpu_label
-      elif type -a nvidia-smi >> /dev/null; then
-        # if nvidia-smi is installed, its highly likely for the gpu to be nvidia, so stop checking
-        echo "NVIDIA"
       else
+        # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
-        echo $gpu
+        if [[ -n $gpu ]]; then
+          # if a gpu is detected, return it
+          echo $gpu
+        elif type -a nvidia-smi >> /dev/null; then
+          # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
+          echo "NVIDIA"
+        fi
       fi
       ;;
 

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -9,9 +9,12 @@ get_platform()
 {
   case $(uname -s) in
     Linux)
-      # use this option for when you know that there is an NVIDIA gpu, but you cant use lspci to determine
-      ignore_lspci=$(get_tmux_option "@dracula-ignore-lspci" false)
-      if [[ "$ignore_lspci" = true ]]; then
+      # use this option for when your gpu isn't detected
+      gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
+      if [[ "$gpu_label" != false ]]; then
+        echo $gpu_label
+      elif type -a nvidia-smi >> /dev/null; then
+        # if nvidia-smi is installed, its highly likely for the gpu to be nvidia, so stop checking
         echo "NVIDIA"
       else
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -20,7 +20,10 @@ get_platform()
       ;;
 
     Darwin)
-      # TODO - Darwin/Mac compatability
+      # WARNING: for this to work the powermetrics command needs to be run without password
+      #   add this to the sudoers file, replacing the username and omitting the quotes.
+      #   be mindful of the tabs: "username		ALL = (root) NOPASSWD: /usr/bin/powermetrics"
+      echo "apple"
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)
@@ -34,6 +37,8 @@ get_gpu()
   gpu=$(get_platform)
   if [[ "$gpu" == NVIDIA ]]; then
     usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{ sum += $0 } END { printf("%d%%\n", sum / NR) }')
+  elif [[ "$gpu" == apple ]]; then
+    usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'active residency' | sed 's/[^0-9.%]//g' | sed 's/[%].*$//g')%"
   else
     usage='unknown'
   fi


### PR DESCRIPTION
- adding support for apple M chip gpus (usage and power, but not vram) 
current solution sadly requires sudo privileges. if i can find something better, i will make another pull-request
- changing to nvidia gpu detection by checking for presence of nvidia-smi tool. 
if nvidia-smi is not installed, it doesnt matter whether an NVIDIA gpu is installed, since we couldnt read the data anyways.
if it is installed, theres most probably also a gpu, because why would you install nvidia drivers otherwise?
- changing from dracula-ignore-lspci to dracula-force-gpu option.
by default its set to false, and doesnt do anything, but you can set it to "NVIDIA", making it as if NIVDIA was detected.
hopefully this will not need to be used for nvidia anymore with the switch to `type -a nvidia-smi` for detection.
- adding percentage option for vram and power
- adding option for finer grained info on vram usage

since i neither own an intel, nor amd gpu, i cannot test these changes for the respective brands. however im planning on teaming up soon to tackle that too.

roadmap:
- intel/ amd support
- multiple gpu support 
- adding all this info to the documentation