### PR TITLE
weather.sh: added timeouts & checking for 'wttr.in'

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -69,10 +69,10 @@ forecast_unicode()
 main()
 {
   # process should be cancelled when session is killed
-  if (echo > /dev/tcp/ipinfo.io/443) >/dev/null 2>&1; then
+  if timeout 1 bash -c "</dev/tcp/ipinfo.io/443" && timeout 1 bash -c "</dev/tcp/wttr.in/443"; then
     echo "$(display_weather)$(display_location)"
   else
-    echo "Location Unavailable"
+    echo "Weather Unavailable"
   fi
 }
 


### PR DESCRIPTION
This is a follow on to my previous request that changed how status was checked for the weather sites. This edit is still using BASH's builtin TCP connections for testing. Added the timeout command so that the status bar doesn't have "NOT READY". Also added a check for 'wttr.in' port 443 as that site is used to get the actual weather information.

I also changed the displayed message when either site is unavailable from "Location Unavailable" to "Weather Unavailable" as it could be either 'wttr.in' or 'ipinfo.io' that is down and causing the error.