### PR TITLE
fix: emulate timeout command for OSX

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -6,6 +6,13 @@ fahrenheit=$1
 location=$2
 fixedlocation=$3
 
+# emulate timeout command from bash - timeout is not available by default on OSX
+if [ "$(uname)" == "Darwin" ]; then
+  timeout() {
+      perl -e 'alarm shift; exec @ARGV' "$duration" "$@"
+  }
+fi
+
 display_location()
 {
   if $location && [[ ! -z "$fixedlocation" ]]; then


### PR DESCRIPTION
`timeout` command is not available in bash on OSX by default. This PR checks weather the OS is OSX and creates a `timeout` function emulating the timeout behaviour.