### PR TITLE
Add icon for AC mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ Configuration and options can be found at [draculatheme.com/tmux](https://dracul
 - When prefix is enabled, a smiley face turns from green to yellow
 - When charging, 'AC' is displayed
     - Alternatively show battery level and whether its charging next to percentage by setting:
-    `set -g @dracula-battery-label false`
-    `set -g @dracula-show-battery-status true`
+    ```
+    set -g @dracula-battery-label false
+    set -g @dracula-no-battery-label false
+    set -g @dracula-show-battery-status true
+    ```
 - If forecast information is available, a ☀, ☁, ☂, or ❄ unicode character corresponding with the forecast is displayed alongside the temperature
 - Info if the Panes are synchronized
 - Spotify playback (needs the tool spotify-tui installed). max-len can be configured.

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -151,7 +151,7 @@ battery_status()
 main()
 {
   bat_label=$(get_tmux_option "@dracula-battery-label" "♥")
-  if [ "$bat_label" ]; then
+  if [ "$bat_label" == false ]; then
     bat_label=""
   fi
 

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -155,6 +155,11 @@ main()
     bat_label=""
   fi
 
+  no_bat_label=$(get_tmux_option "@dracula-no-battery-label" "AC")
+  if [ "$no_bat_label" == false ]; then
+    no_bat_label=""
+  fi
+
   show_bat_label=$(get_tmux_option "@dracula-show-battery-status" false)
   if $show_bat_label; then
     bat_stat=$(battery_status)
@@ -167,7 +172,7 @@ main()
   if [ -z "$bat_stat" ]; then # Test if status is empty or not
     echo "$bat_label $bat_perc"
   elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
-    echo ""
+    echo "$no_bat_label"
   else
     echo "$bat_label$bat_stat $bat_perc"
   fi


### PR DESCRIPTION
If tmux theme is run on a desktop the battery space is empty.
Restore the previous behavior displaying AC and an icon.