### PR TITLE
Fix: get status and capacity with multiple power_supplies

### DIFF
--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -9,18 +9,18 @@ linux_acpi() {
   arg=$1
   BAT=$(ls -d /sys/class/power_supply/*)
   if [ ! -x "$(which acpi 2> /dev/null)" ];then
-    case "$arg" in
-      status)
-        cat $BAT/status
-        ;;
-
-      percent)
-        cat $BAT/capacity
-        ;;
-
-      *)
-        ;;
-    esac
+    for DEV in $BAT; do
+      case "$arg" in
+        status)
+          [ -f "$DEV/status" ] && cat "$DEV/status"
+          ;;
+        percent)
+          [ -f "$DEV/capacity" ] && cat "$DEV/capacity"
+          ;;
+        *)
+          ;;
+      esac
+    done
   else
     case "$arg" in
       status)


### PR DESCRIPTION
It is possible that $BAT contains multiple power_supplies like
```bash
/sys/class/power_supply/AC
/sys/class/power_supply/BAT0
/sys/class/power_supply/ucsi-source-psy-USBC000:001
```
In such a case, the original code becomes
`cat AC BAT0 ucsi-source-psy-USBC000:001/status` (path prefix omitted). It fails to run because you cannot `cat` a directory.