### PR TITLE
Add transparent background to the powerline

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -54,10 +54,8 @@ main()
   # Set color of background
   if $transparent_powerline_bg; then
     bg_color="default"
-    separator_bg_color="default"
   else
     bg_color=${gray}
-    separator_bg_color=${white}
   fi
 
   # Handle left icon configuration
@@ -139,8 +137,8 @@ main()
 
   # Status left
   if $show_powerline; then
-    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=default]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
-    powerbg=default
+    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${bg_color}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
+    powerbg=${bg_color}
   else
     tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
   fi
@@ -308,7 +306,7 @@ main()
   # Window option
   if $show_powerline; then
     if $transparent_powerline_bg; then
-    tmux set-window-option -g window-status-current-format "#[fg=${dark_purple},bg=default]${inverse_divider}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=default]${left_sep}"
+    tmux set-window-option -g window-status-current-format "#[fg=${dark_purple},bg=${bg_color}]${inverse_divider}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${bg_color}]${left_sep}"
     else
     tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
     fi
@@ -316,7 +314,7 @@ main()
     tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
   fi
 
-  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=default] #I #W${flags}"
+  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${bg_color}] #I #W${flags}"
   tmux set-window-option -g window-status-activity-style "bold"
   tmux set-window-option -g window-status-bell-style "bold"
 }

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -51,11 +51,17 @@ main()
   pink='#ff79c6'
   yellow='#f1fa8c'
 
-  # Set color of background
+  # Set transparency variables - Colors and window dividers
   if $transparent_powerline_bg; then
     bg_color="default"
+    window_sep_fg=${dark_purple}
+    window_sep_bg=default
+    window_sep="$show_inverse_divider"
   else
     bg_color=${gray}
+    window_sep_fg=${gray}
+    window_sep_bg=${dark_purple}
+    window_sep="$show_left_sep"
   fi
 
   # Handle left icon configuration
@@ -305,11 +311,7 @@ main()
 
   # Window option
   if $show_powerline; then
-    if $transparent_powerline_bg; then
-    tmux set-window-option -g window-status-current-format "#[fg=${dark_purple},bg=${bg_color}]${inverse_divider}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${bg_color}]${left_sep}"
-    else
-    tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
-    fi
+    tmux set-window-option -g window-status-current-format "#[fg=${window_sep_fg},bg=${window_sep_bg}]${window_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${bg_color}]${left_sep}"
   else
     tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
   fi

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -18,6 +18,7 @@ main()
   show_location=$(get_tmux_option "@dracula-show-location" true)
   fixed_location=$(get_tmux_option "@dracula-fixed-location")
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
+  transparent_bg=$(get_tmux_option "@dracula-transparent-bg" false)
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
   show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
@@ -26,6 +27,7 @@ main()
   show_timezone=$(get_tmux_option "@dracula-show-timezone" true)
   show_left_sep=$(get_tmux_option "@dracula-show-left-sep" )
   show_right_sep=$(get_tmux_option "@dracula-show-right-sep" )
+  show_inverse_divider=$(get_tmux_option "@dracula-inverse-divider" )
   show_border_contrast=$(get_tmux_option "@dracula-border-contrast" false)
   show_day_month=$(get_tmux_option "@dracula-day-month" false)
   show_refresh=$(get_tmux_option "@dracula-refresh-rate" 5)
@@ -48,6 +50,15 @@ main()
   red='#ff5555'
   pink='#ff79c6'
   yellow='#f1fa8c'
+
+  # Set color of background
+  if $transparent_bg; then
+    bg_color="default"
+    separator_bg_color="default"
+  else
+    bg_color=${gray}
+    separator_bg_color=${white}
+  fi
 
   # Handle left icon configuration
   case $show_left_icon in
@@ -76,6 +87,7 @@ main()
   if $show_powerline; then
     right_sep="$show_right_sep"
     left_sep="$show_left_sep"
+    inverse_divider="$show_inverse_divider"
   fi
 
   # Set timezone unless hidden by configuration
@@ -123,12 +135,12 @@ main()
   tmux set-option -g message-style "bg=${gray},fg=${white}"
 
   # status bar
-  tmux set-option -g status-style "bg=${gray},fg=${white}"
+  tmux set-option -g status-style "bg=${bg_color},fg=${white}"
 
   # Status left
   if $show_powerline; then
-    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${gray}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
-    powerbg=${gray}
+    tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=default]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
+    powerbg=default
   else
     tmux set-option -g status-left "#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon}"
   fi
@@ -295,12 +307,16 @@ main()
 
   # Window option
   if $show_powerline; then
+    if $transparent_bg; then
+    tmux set-window-option -g window-status-current-format "#[fg=${dark_purple},bg=default]${inverse_divider}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=default]${left_sep}"
+    else
     tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"
+    fi
   else
     tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "
   fi
 
-  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=${gray}] #I #W${flags}"
+  tmux set-window-option -g window-status-format "#[fg=${white}]#[bg=default] #I #W${flags}"
   tmux set-window-option -g window-status-activity-style "bold"
   tmux set-window-option -g window-status-bell-style "bold"
 }

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -18,7 +18,7 @@ main()
   show_location=$(get_tmux_option "@dracula-show-location" true)
   fixed_location=$(get_tmux_option "@dracula-fixed-location")
   show_powerline=$(get_tmux_option "@dracula-show-powerline" false)
-  transparent_bg=$(get_tmux_option "@dracula-transparent-bg" false)
+  transparent_powerline_bg=$(get_tmux_option "@dracula-transparent-powerline-bg" false)
   show_flags=$(get_tmux_option "@dracula-show-flags" false)
   show_left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
   show_left_icon_padding=$(get_tmux_option "@dracula-left-icon-padding" 1)
@@ -52,7 +52,7 @@ main()
   yellow='#f1fa8c'
 
   # Set color of background
-  if $transparent_bg; then
+  if $transparent_powerline_bg; then
     bg_color="default"
     separator_bg_color="default"
   else
@@ -307,7 +307,7 @@ main()
 
   # Window option
   if $show_powerline; then
-    if $transparent_bg; then
+    if $transparent_powerline_bg; then
     tmux set-window-option -g window-status-current-format "#[fg=${dark_purple},bg=default]${inverse_divider}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=default]${left_sep}"
     else
     tmux set-window-option -g window-status-current-format "#[fg=${gray},bg=${dark_purple}]${left_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${gray}]${left_sep}"

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -91,7 +91,6 @@ main()
   if $show_powerline; then
     right_sep="$show_right_sep"
     left_sep="$show_left_sep"
-    inverse_divider="$show_inverse_divider"
   fi
 
   # Set timezone unless hidden by configuration


### PR DESCRIPTION
I've tried to create the least possible if statements to achieve this. This should solve #101 

I've added the 2 following options:
1. @dracula-transparent-powerline-bg -> Default to false, set background transparency on the powerline
2. @dracula-inverse-divider -> I had to change the divider for the window panes because I couldn't get the foreground color to be transparent, only the backgroud. So I've set this inversed divider to be used if *transparent-powerline-bg* is set to *true*. I've added it to the options so the user could use another divider if he had decided to change the *show-left-sep*

I've added some new variables :
1. bg_color -> set the backgroud color
2. window_sep_fg -> set the foreground color of the windows separator (it is necessary to change it if we use the inversed divider)
3. window_sep_bg -> set the background of the windows separator, same reasons as *window_sep_fg*
4. window_sep -> sets the divider used between the windows.

Those variables and their placement in the code allows no other if statement than setting those variables. I've tried to name the variables with something similar that was already used.

I've checked the powerline with *transparent-powerline-bg* set as false or without using it in *tmux.conf* and I can't find any differences from the original code.

This change doesn't seem to break anything. I haven't touched the right side of the bar since it seemed to be filled. I don't use much plugins though but I've tested it with **ssh-session**, **git** and **playerctl** and I can't find anything that breaks.