### PR TITLE
Bug/no wifi icon on linux

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -7,6 +7,8 @@ source $current_dir/utils.sh
 
 # set your own hosts so that a wifi is recognised even without internet access
 HOSTS=$(get_tmux_option "@dracula-network-hosts" "google.com github.com example.com")
+wifi_label=$(get_tmux_option "@dracula-network-wifi-label" "")
+ethernet_label=$(get_tmux_option "@dracula-network-ethernet-label" "Ethernet")
 
 get_ssid()
 {
@@ -17,16 +19,15 @@ get_ssid()
       if [ -n "$SSID" ]; then
         printf '%s' "$wifi_label$SSID"
       else
-        echo "$(get_tmux_option "@dracula-network-ethernet-label" "Ethernet")"
+        echo "$ethernet_label"
       fi
       ;;
 
     Darwin)
       if networksetup -getairportnetwork en0 | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
-        wifi_label=$(get_tmux_option "@dracula-network-wifi-label" "")
         echo "$wifi_label$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
       else
-        echo "$(get_tmux_option "@dracula-network-ethernet-label" "Ethernet")"
+        echo "$ethernet_label"
       fi
       ;;
 

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -17,7 +17,7 @@ get_ssid()
     Linux)
       SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
       if [ -n "$SSID" ]; then
-        printf '%s' "$wifi_label$SSID"
+        echo "$wifi_label$SSID"
       else
         echo "$ethernet_label"
       fi
@@ -45,7 +45,7 @@ main()
 {
   network="$(get_tmux_option "@dracula-network-offline-label" "Offline")"
   for host in $HOSTS; do
-    if ping -q -c 1 -W 1 $host &>/dev/null; then
+    if ping -q -c 1 -W 1 "$host" &>/dev/null; then
       network="$(get_ssid)"
       break
     fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
 get_tmux_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-option -gqv "$option")
+  local option="$1"
+  local default_value="$2"
+  local option_value="$(tmux show-option -gqv "$option")"
   if [ -z "$option_value" ]; then
-    echo $default_value
+    echo "$default_value"
   else
-    echo $option_value
+    echo "$option_value"
   fi
 }
 
 get_tmux_window_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-window-options -v "$option")
+  local option="$1"
+  local default_value="$2"
+  local option_value="$(tmux show-window-options -v "$option")"
   if [ -z "$option_value" ]; then
-    echo $default_value
+    echo "$default_value"
   else
-    echo $option_value
+    echo "$option_value"
   fi
 }
 


### PR DESCRIPTION
there was an issue preventing the wifi label option from being shown on linux. upon fixing that i realised that whitespaces kept being stripped from tmux options, so i fixed that issue too.