### PR TITLE
mac: Fix network detection

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -24,8 +24,13 @@ get_ssid()
       ;;
 
     Darwin)
-      if networksetup -getairportnetwork en0 | cut -d ':' -f 2 | sed 's/^[[:blank:]]*//g' &> /dev/null; then
-        echo "$wifi_label$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)" | sed 's/^[[:blank:]]*//g'
+      local wifi_network=$(ipconfig getsummary en0 | awk -F ' SSID : '  '/ SSID : / {print $2}')
+      local airport=$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)
+
+      if [[ $airport != "You are not associated with an AirPort network." ]]; then
+        echo "$wifi_label$airport" | sed 's/^[[:blank:]]*//g'
+      elif [[ $wifi_network != "" ]]; then
+        echo "$wifi_label$wifi_network" | sed 's/^[[:blank:]]*//g'
       else
         echo "$ethernet_label"
       fi


### PR DESCRIPTION
There air wifi networks that are not compatible with AirPort. In such a case the network.sh script does not detect correctly the SSID.

The message reported is:
  "You are not associated with an AirPort network."

Fix the script detecting correctly the SSID of networks that do not support AirPort.