### PR TITLE
The weather plugin is broken: revert the latest changes to make it functional again

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -42,7 +42,6 @@ fetch_weather_information()
 #get weather display
 display_weather()
 {
-  fahrenheit=$1
   if $fahrenheit; then
     display_weather='&u' # for USA system
   else
@@ -74,24 +73,13 @@ forecast_unicode()
   fi
 }
 
-export -f display_weather
-export -f display_location
-export -f forecast_unicode
-export -f fetch_weather_information
-
 main()
 {
   # process should be cancelled when session is killed
   if timeout 1 bash -c "</dev/tcp/ipinfo.io/443" && timeout 1 bash -c "</dev/tcp/wttr.in/443"; then
-    if ! weather=$(timeout 3 bash -c "display_weather $fahrenheit"); then
-      echo "Weather Unavailable"
-    elif ! location=$(timeout 3 bash -c display_location); then
-      echo "Location Unavailable"
-    else
-      echo "${weather}${location}"
-    fi
+    echo "$(display_weather)$(display_location)"
   else
-    echo "Network Error"
+    echo "Weather Unavailable"
   fi
 }
 

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -11,7 +11,6 @@ fixedlocation=$3
 DATAFILE=/tmp/.dracula-tmux-data
 LAST_EXEC_FILE="/tmp/.dracula-tmux-weather-last-exec"
 RUN_EACH=1200
-RETRY_EACH=60
 TIME_NOW=$(date +%s)
 TIME_LAST=$(cat "${LAST_EXEC_FILE}" 2>/dev/null || echo "0")
 
@@ -20,10 +19,6 @@ main()
   current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
   if [ "$(expr ${TIME_LAST} + ${RUN_EACH})" -lt "${TIME_NOW}" ]; then
-    # Run weather script here
-    $current_dir/weather.sh $fahrenheit $location "$fixedlocation" > "${DATAFILE}"
-    echo "${TIME_NOW}" > "${LAST_EXEC_FILE}"
-  elif grep -q 'Unavailable\|Error' "${DATAFILE}" && [ "$(expr ${TIME_LAST} + ${RETRY_EACH})" -lt "${TIME_NOW}" ]; then
     # Run weather script here
     $current_dir/weather.sh $fahrenheit $location "$fixedlocation" > "${DATAFILE}"
     echo "${TIME_NOW}" > "${LAST_EXEC_FILE}"


### PR DESCRIPTION
The weather plugin:
- On Mac: reports empty results because the default bash is stack to version 3 and seems not cooping with the changes reverted
- On Linux: it work but reports the wrong location

Propose to revert the changes to make it working again.