### PR TITLE
weather.sh: Introduce fallback when wttr.in reaches call limit

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -53,9 +53,14 @@ display_weather()
   temperature=$(echo $weather_information | rev | cut -d ' ' -f 1 | rev) # +31°C, -3°F, etc
   unicode=$(forecast_unicode $weather_condition)
 
+  # Mac Only variant should be transparent on Linux
+  if [[ "${temperature/+/}" == *"===="* ]]; then
+    temperature="error"
+  fi
+
   if [[ "${temperature/+/}" == "error" ]]; then
     # Propagate Error
-    echo "${temperature/+/}"
+    echo "error"
   else
     echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
   fi

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -53,7 +53,12 @@ display_weather()
   temperature=$(echo $weather_information | rev | cut -d ' ' -f 1 | rev) # +31°C, -3°F, etc
   unicode=$(forecast_unicode $weather_condition)
 
-  echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
+  if [[ "${temperature/+/}" == "error" ]]; then
+    # Propagate Error
+    echo "${temperature/+/}"
+  else
+    echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
+  fi
 }
 
 forecast_unicode()
@@ -76,7 +81,7 @@ forecast_unicode()
 main()
 {
   # process should be cancelled when session is killed
-  if timeout 1 bash -c "</dev/tcp/ipinfo.io/443" && timeout 1 bash -c "</dev/tcp/wttr.in/443"; then
+  if timeout 1 bash -c "</dev/tcp/ipinfo.io/443" && timeout 1 bash -c "</dev/tcp/wttr.in/443" && [[ "$(display_weather)" != "error" ]]; then
     echo "$(display_weather)$(display_location)"
   else
     echo "Weather Unavailable"


### PR DESCRIPTION
When wttr.in reaches call limit returns the following:

Sorry, we are running out of queries to the weather service at the moment. Here is the weather report for the default city (just to show you what it looks like). We will get new queries as soon as possible.
You can follow https://twitter.com/igor_chubin for the updates.

Which makes weather.sh display a random error.

Make the error predictable.