### PR TITLE
Adding GPU Use/mem/power for AMD & Intel GPUs

### DIFF
--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -52,9 +52,15 @@ get_gpu()
   elif [[ "$gpu" == apple ]]; then
     usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'GPU Power' | sed 's/GPU Power: \(.*\) \(.*\)/\1\2/g')"
   else
-    usage='unknown'
+    usage=$(
+      for card in /sys/class/drm/card?
+      do
+        echo "$(($(cat "$card"/device/hwmon/hwmon?/power1_average) / 1000 / 1000))/$(($(cat "$card"/device/hwmon/hwmon?/power1_cap_max) / 1000 / 1000))W"
+      done | \
+      sed -z -e 's/\n/|/g' -e 's/|$//g'
+    )
   fi
-  normalize_percent_len $usage
+  echo $usage
 }
 
 main()

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -51,7 +51,7 @@ get_gpu()
 
   elif [[ "$gpu" == apple ]]; then
     usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'GPU Power' | sed 's/GPU Power: \(.*\) \(.*\)/\1\2/g')"
-  else
+  elif [[ "$gpu" == Advanced ]]; then
     usage=$(
       for card in /sys/class/drm/card?
       do
@@ -59,6 +59,8 @@ get_gpu()
       done | \
       sed -z -e 's/\n/|/g' -e 's/|$//g'
     )
+  else # "Intel" "Matrox", etc
+    usage="unknown"
   fi
   echo $usage
 }

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -52,7 +52,14 @@ get_gpu()
       usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk "{ used += \$0; total +=\$2 } END { printf(\"%${used_accuracy}GB/%${total_accuracy}GB\n\", used / 1024, total / 1024) }")
     fi
   else
-    usage='unknown'
+    usage="$(
+      for card in /sys/class/drm/card?
+      do
+        use=$(cat "$card"/device/mem_info_vram_used | numfmt --to=iec --suffix=B)
+        max=$(cat "$card"/device/mem_info_vram_total | numfmt --to=iec --suffix=B)
+        echo "$use/$max"
+      done | sed -z -e 's/\n/|/g' -e 's/|$//g'
+    )"
   fi
   echo $usage
 }

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -51,7 +51,7 @@ get_gpu()
       total_accuracy=$(get_tmux_option "@dracula-gpu-vram-total-accuracy" "d")
       usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk "{ used += \$0; total +=\$2 } END { printf(\"%${used_accuracy}GB/%${total_accuracy}GB\n\", used / 1024, total / 1024) }")
     fi
-  else
+  elif [[ "$gpu" == Advanced ]]; then
     usage="$(
       for card in /sys/class/drm/card?
       do
@@ -60,6 +60,8 @@ get_gpu()
         echo "$use/$max"
       done | sed -z -e 's/\n/|/g' -e 's/|$//g'
     )"
+  else # "Intel" "Matrox", etc
+    usage="unknown"
   fi
   echo $usage
 }

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -47,7 +47,7 @@ get_gpu()
   elif [[ "$gpu" == apple ]]; then
     usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'active residency' | sed 's/[^0-9.%]//g' | sed 's/[%].*$//g')%"
   else
-    usage='unknown'
+    usage="$(cat /sys/class/drm/card?/device/gpu_busy_percent | sed -z -e 's/\n/%|/g' -e 's/|$//g')"
   fi
   normalize_percent_len $usage
 }

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -46,8 +46,10 @@ get_gpu()
     usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | awk '{ sum += $0 } END { printf("%d%%\n", sum / NR) }')
   elif [[ "$gpu" == apple ]]; then
     usage="$(sudo powermetrics --samplers gpu_power -i500 -n 1 | grep 'active residency' | sed 's/[^0-9.%]//g' | sed 's/[%].*$//g')%"
-  else
+  elif [[ "$gpu" == Advanced ]]; then
     usage="$(cat /sys/class/drm/card?/device/gpu_busy_percent | sed -z -e 's/\n/%|/g' -e 's/|$//g')"
+  else # "Intel" "Matrox", etc
+    usage="unknown"
   fi
   normalize_percent_len $usage
 }


### PR DESCRIPTION
Changes unknown outputs by `scripts/gpu_*` to be the correct output for 1 or more AMD/Intel GPUs


`GPU 0%|0%  VRAM 34MB/4.0GB|1.2GB/8.0GB  GPUP 1/43W|16/156W`