### PR TITLE
check whether output is empty and exit before entering scrolling output

### DIFF
--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -41,6 +41,13 @@ main() {
   start=0
   len=${#playerctl_playback}
 
+  # previously we have appended a space to playerctl_playback
+  # if there is no player, len sees only one space
+  # exit the script and output nothing if there is just that space
+  if [[ $len == 1 ]]; then
+    exit
+  fi
+
   scrolling_text=""
 
   for ((start = 0; start <= len; start++)); do


### PR DESCRIPTION
the playerctl plugin is outputting a lot of white space when nothing is running.
this pr aims to fix that and kill any output if nothing is running.

in reference to #312 
i would like @joncvn from that issue to review this pr properly, as i wasnt able to do that right now