### PR TITLE
add tommorow night color scheme

### DIFF
--- a/docs/color_theming/README.md
+++ b/docs/color_theming/README.md
@@ -62,3 +62,4 @@ set -g @dracula-colors " white='#f8f8f2' gray='#44475a' dark_gray='#282a36' ligh
 as part of this directory there are some plug and play themes with explanations on how to use them:
 - [catppuccin](/docs/color_theming/catppuccin.md)
 - [gruvbox](/docs/color_theming/gruvbox.md)
+- [tomorrow night](/docs/color_theming/tomorrow_night.md)

--- a/docs/color_theming/tomorrow_night.md
+++ b/docs/color_theming/tomorrow_night.md
@@ -19,7 +19,7 @@ dark_purple='#373b41'
 "
 ```
 
-Alternatively use the full gruvbox color palette and customise the flags accordingly
+Alternatively use the full tomorrow color palette and customise the flags accordingly
 
 # Tomorrow Night Color Palette
 ## Tomorrow
@@ -102,3 +102,5 @@ blue='#bbdaff'
 purple='#ebbbff'
 pane='#4d5057'
 ```
+
+>For more information about the tomorrow theme, here is the repo made by [chriskempson](https://github.com/chriskempson/tomorrow-theme/tree/master)

--- a/docs/color_theming/tomorrow_night.md
+++ b/docs/color_theming/tomorrow_night.md
@@ -1,0 +1,104 @@
+# drac to tomorrow night
+
+for a quick setup, set the following option:
+```
+set -g @dracula-colors "
+# simple tomorrow night color palette
+pink='#cc6666'
+orange='#de935f'
+yellow='#f0c574'
+green='#b5bd68'
+cyan='#8abdb6'
+blue='#81a2be'
+light_purple='#b294ba'
+white='#c4c8c5'
+dark_gray='#363a41'
+red='#cc6666'
+gray='#1d1f21'
+dark_purple='#373b41'
+"
+```
+
+Alternatively use the full gruvbox color palette and customise the flags accordingly
+
+# Tomorrow Night Color Palette
+## Tomorrow
+```
+foreground='#4d4d4c'
+background='#ffffff'
+highlight='#d6d6d6'
+status_line='#efefef'
+comment='#8e908c'
+red='#c82829'
+orange='#f5871f'
+yellow='#eab700'
+green='#718c00'
+aqua='#3e999f'
+blue='#4271ae'
+purple='#8959a8'
+pane='#efefef'
+```
+## Tomorrow Night
+```
+foreground='#c5c8c6'
+background='#1d1f21'
+highlight='#373b41'
+status_line='#282a2e'
+comment='#969896'
+red='#cc6666'
+orange='#de935f'
+yellow='#f0c674'
+green='#b5bd68'
+aqua='#8abeb7'
+blue='#81a2be'
+purple='#b294bb'
+pane='#4d5057'
+```
+## Tomorrow Night Eighties
+```
+foreground='#4d4d4c'
+background='#ffffff'
+highlight='#d6d6d6'
+status_line='#efefef'
+comment='#8e908c'
+red='#c82829'
+orange='#f5871f'
+yellow='#eab700'
+green='#718c00'
+aqua='#3e999f'
+blue='#4271ae'
+purple='#8959a8'
+pane='#efefef'
+```
+## Tomorrow Night Bright
+```
+foreground='#eaeaea'
+background='#000000'
+highlight='#424242'
+status_line='#2a2a2a'
+comment='#969896'
+red='#d54e53'
+orange='#e78c45'
+yellow='#e7c547'
+green='#b9ca4a'
+aqua='#70c0b1'
+blue='#7aa6da'
+purple='#c397d8'
+pane='#4d5057'
+```
+## Tomorrow Night Blue
+```
+foreground='#ffffff'
+background='#002451'
+highlight='#003f8e'
+status_line='#00346e'
+comment='#7285b7'
+red='#ff9da4'
+orange='#ffc58f'
+yellow='#ffeead'
+green='#d1f1a9'
+aqua='#99ffff'
+blue='#bbdaff'
+purple='#ebbbff'
+pane='#4d5057'
+```


### PR DESCRIPTION
As referenced in issue #312, I am proposing a new colorscheme into the doc, the [tomorrow-theme](https://github.com/chriskempson/tomorrow-theme/tree/master)
Here is below few screenshots of each theme applied for tmux: 
### Tomorrow
![image](https://github.com/user-attachments/assets/ef922c99-c630-4a72-b439-7944981d5bed)

### Tomorrow Night
![tomorrow_night](https://github.com/user-attachments/assets/dbc4ca4e-8420-4432-bd53-27ff614c049d)
### Tomorrow Night Eighties
![image](https://github.com/user-attachments/assets/7aa04f72-97af-4412-a126-5e1e195f761d)
### Tomorrow Night Bright
![image](https://github.com/user-attachments/assets/e0c52f83-ab65-448a-b5d5-9ca59c57e0c5)

### Tomorrow Night Blue
![image](https://github.com/user-attachments/assets/d0387992-3a34-48e1-a1f7-b7536fc08c99)
