### PR TITLE
Provide option to cwd that shortens the path to solely display the current directory

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -17,6 +17,14 @@ main() {
 
   # change '/home/user' to '~'
   cwd="${path/"$HOME"/'~'}"
+  
+  # check if the user wants only the current directory
+  basename_enabled=$(tmux show-option -gqv @dracula-cwd-basename)
+
+  if ["$basenmae_enabled" == "true" ]; then
+     #Extract only the last part of path
+     cwd=$(basename "cwd") 
+  fi
 
   echo "$cwd"
 }

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -21,13 +21,16 @@ main() {
   # check if the user wants only the current directory
   basename_enabled=$(tmux show-option -gqv @dracula-cwd-basename)
 
-  if ["$basenmae_enabled" == "true" ]; then
+  if [ "$basename_enabled" == "true" ]; then
     #Extract only the last part of path
     cwd=$(basename "$cwd")
   fi
 
   echo "$cwd"
 }
+
+# Enable debugging
+set -x
 
 #run main driver program
 main

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -17,13 +17,13 @@ main() {
 
   # change '/home/user' to '~'
   cwd="${path/"$HOME"/'~'}"
-  
+
   # check if the user wants only the current directory
   basename_enabled=$(tmux show-option -gqv @dracula-cwd-basename)
 
   if ["$basenmae_enabled" == "true" ]; then
-     #Extract only the last part of path
-     cwd=$(basename "cwd") 
+    #Extract only the last part of path
+    cwd=$(basename "$cwd")
   fi
 
   echo "$cwd"

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -29,8 +29,5 @@ main() {
   echo "$cwd"
 }
 
-# Enable debugging
-set -x
-
 #run main driver program
 main


### PR DESCRIPTION
I'm a big fan of the `cwd` feature, but with the amount of directories and subdirectories I have, seeing the verbosity of my paths displayed by Dracula's `cwd` can be a bit annoying, especially when I have other plugins displayed within the powerline.

#### Turn this: `'~'/very/long/and/verbose/path/to/users/CurrentDirectory`
#### Into this: `CurrentDirectory` 

To do so, simply enter the following within `.tmux.conf`:
`set -g @dracula-cwd-basename true`

If merged, I hope this provides some value to users working with this wonderful plugin.