### PR TITLE
Default show_only_kubernetes_context to false

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -10,7 +10,7 @@ main() {
   show_krbtgt_label=$(get_tmux_option "@dracula-krbtgt-context-label" "")
   krbtgt_principal=$(get_tmux_option "@dracula-krbtgt-principal" "")
   show_kubernetes_context_label=$(get_tmux_option "@dracula-kubernetes-context-label" "")
-  show_only_kubernetes_context=$(get_tmux_option "@dracula-show-only-kubernetes-context" "")
+  show_only_kubernetes_context=$(get_tmux_option "@dracula-show-only-kubernetes-context" false)
   eks_hide_arn=$(get_tmux_option "@dracula-kubernetes-eks-hide-arn" false)
   eks_extract_account=$(get_tmux_option "@dracula-kubernetes-eks-extract-account" false)
   hide_kubernetes_user=$(get_tmux_option "@dracula-kubernetes-hide-user" false)


### PR DESCRIPTION
This fixes a bug on the `@dracula-kubernetes-context-label` option in `kubernetes_context` plugin.

`kubernetes_context.sh` is called with positional args as such:

```
kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_only_kubernetes_context $show_kubernetes_context_label
```

When `show_only_kubernetes_context` defaults to "", arg $5 `show_kubernetes_context_label`,  becomes arg $4 `show_only_kubernetes_context`. Effectively, the value of `@dracula-kubernetes-context-label` is passed to the script as `show_only_kubernetes_context` instead of `show_kubernetes_context_label` So the default value for `show_only_kubernetes_context` needs to be a non-zero string.

Here are screenshots showing the bug:

`@dracula-kubernetes-context-label` has no effect when `@dracula-show-only-kubernetes-context` is `""`.
<img width="755" alt="Screenshot 2025-01-29 at 7 59 05 PM" src="https://github.com/user-attachments/assets/2fc9b436-dd9a-4e59-8e46-836f38d56cee" />

`@dracula-kubernetes-context-label` has no effect when `@dracula-show-only-kubernetes-context` is not set.
<img width="754" alt="Screenshot 2025-01-29 at 7 58 34 PM" src="https://github.com/user-attachments/assets/d3c8d250-37a6-4302-a93e-7b909403466e" />

Setting `@dracula-kubernetes-context-label` to `"true"` is  effectively the same as setting `@dracula-show-only-kubernetes-context` to `"true"`.
<img width="755" alt="Screenshot 2025-01-29 at 8 06 36 PM" src="https://github.com/user-attachments/assets/77813846-0c1b-417b-8d29-172c70547813" />

`@dracula-kubernetes-context-label` only takes effect when `@dracula-show-only-kubernetes-context` is explicitly set to `"false"` or other non-zero length string other than "true".
<img width="757" alt="Screenshot 2025-01-29 at 7 58 02 PM" src="https://github.com/user-attachments/assets/f2fa5e19-8498-4074-aa04-0275ccfa687d" />
