### PR TITLE
feature: add max length feature to cwd

### DIFF
--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -41,7 +41,7 @@ main() {
   fi
 
   cwd_max_chars="$(get_tmux_option "@dracula-cwd-max-chars" "0")"
-  if [[ "${#cwd}" -gt "$cwd_max_chars" ]]; then
+  if [[ "${cwd_max_chars}" -gt 0 && "${#cwd}" -gt "$cwd_max_chars" ]]; then
     cwd="…/…${cwd:(- cwd_max_chars)}"
   fi
 

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
 # return current working directory of tmux pane
 getPaneDir() {
   nextone="false"
@@ -17,6 +20,20 @@ main() {
 
   # change '/home/user' to '~'
   cwd="${path/"$HOME"/'~'}"
+
+  # check max number of subdirs to display. 0 means unlimited
+  cwd_len=$(get_tmux_option "@dracula-cwd-length" "0")
+
+  if [[ "$cwd_len" -gt 0 ]]; then
+    base_to_erase=$cwd
+    for ((i = 0 ; i < cwd_len ; i++)); do
+      base_to_erase="${base_to_erase%/*}"
+    done
+    # / would have #base_to_erase of 0 and ~/ has #base_to_erase of 1. we want to exclude both cases
+    if [[ ${#base_to_erase} -gt 1 ]]; then
+      cwd=${cwd:${#base_to_erase}+1}
+    fi
+  fi
 
   echo "$cwd"
 }

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir/utils.sh"
 
 # return current working directory of tmux pane
 getPaneDir() {
@@ -18,20 +18,25 @@ getPaneDir() {
 main() {
   path=$(getPaneDir)
 
+  if [[ "$path" == "$HOME" ]]; then
+    echo "~"
+    exit 0
+  fi
+
   # change '/home/user' to '~'
-  cwd="${path/"$HOME"/'~'}"
+  cwd="${path/"${HOME}/"/'~/'}"
 
   # check max number of subdirs to display. 0 means unlimited
-  cwd_len=$(get_tmux_option "@dracula-cwd-length" "0")
+  cwd_max_dirs=$(get_tmux_option "@dracula-cwd-max-dirs" "0")
 
-  if [[ "$cwd_len" -gt 0 ]]; then
+  if [[ "$cwd_max_dirs" -gt 0 ]]; then
     base_to_erase=$cwd
-    for ((i = 0 ; i < cwd_len ; i++)); do
+    for ((i = 0 ; i < cwd_max_dirs ; i++)); do
       base_to_erase="${base_to_erase%/*}"
     done
     # / would have #base_to_erase of 0 and ~/ has #base_to_erase of 1. we want to exclude both cases
     if [[ ${#base_to_erase} -gt 1 ]]; then
-      cwd=${cwd:${#base_to_erase}+1}
+      cwd="…/${cwd:${#base_to_erase}+1}"
     fi
   fi
 

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -16,7 +16,7 @@ getPaneDir() {
 }
 
 main() {
-  path=$(getPaneDir)
+  path="$(getPaneDir)"
 
   if [[ "$path" == "$HOME" ]]; then
     echo "~"
@@ -27,7 +27,7 @@ main() {
   cwd="${path/"${HOME}/"/'~/'}"
 
   # check max number of subdirs to display. 0 means unlimited
-  cwd_max_dirs=$(get_tmux_option "@dracula-cwd-max-dirs" "0")
+  cwd_max_dirs="$(get_tmux_option "@dracula-cwd-max-dirs" "0")"
 
   if [[ "$cwd_max_dirs" -gt 0 ]]; then
     base_to_erase=$cwd
@@ -38,6 +38,11 @@ main() {
     if [[ ${#base_to_erase} -gt 1 ]]; then
       cwd="…/${cwd:${#base_to_erase}+1}"
     fi
+  fi
+
+  cwd_max_chars="$(get_tmux_option "@dracula-cwd-max-chars" "0")"
+  if [[ "${#cwd}" -gt "$cwd_max_chars" ]]; then
+    cwd="…/…${cwd:(- cwd_max_chars)}"
   fi
 
   echo "$cwd"


### PR DESCRIPTION
in reference to #324 this pr attempts to implement the suggestion.

tested on macos

not yet documented.

use `set -g @dracula-cwd-length "0"` to set the max length, where 0 is unrestricted.

whenever the paths length is cut, it is displayed without / or ~/ to the left of it to prevent confusion.

example:
max length is 1:
/ becomes / as usual
/Users becomes /Users as usual
/Users/username becomes ~ as usual
/Users/username/.config becomes ~/.config as usual
/Users/username/.config/tmux becomes tmux. no / to the left indicates a cut path
max length is 3:
/Users/username/.config becomes ~/.config as usual
/Users/username/.config/tmux/plugins becomes ~/.config/tmux/plugins as usual
/Users/username/.config/tmux/plugins/tmux becomes tmux. no / to the left indicates a cut path
max length is 0:
unchanged behaviour to previously

my solution seems hacky, but i couldnt think of anything else at this time of day. 
please critique or suggest a different solution.

documentation and testing on linux will follow.