### PR TITLE
refactor(weather): Fix timeout, reduce calls, apply shellcheck

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -2,96 +2,110 @@
 # setting the locale, some users have issues with different locales, this forces the correct one
 export LC_ALL=C.utf8
 
-fahrenheit=$1
-location=$2
-fixedlocation=$3
+API_URL="https://wttr.in"
+DELIM=":"
 
 # emulate timeout command from bash - timeout is not available by default on OSX
 if [ "$(uname)" == "Darwin" ]; then
-  timeout() {
-      perl -e 'alarm shift; exec @ARGV' "$duration" "$@"
+  function timeout() {
+    local _duration
+    _duration="${1:-1}"
+    command -p perl -e 'alarm shift; exec @ARGV' "$_duration" "$@"
   }
 fi
 
-display_location()
-{
-  if $location && [[ ! -z "$fixedlocation" ]]; then
-    echo " $fixedlocation"
-  elif $location; then
-    city=$(curl -s https://ipinfo.io/city 2> /dev/null)
-    region=$(curl -s https://ipinfo.io/region 2> /dev/null)
-    echo " $city, $region"
+# Fetch weather information from remote API
+# Globals:
+#   DELIM
+# Arguments:
+#   show fahrenheit, either "true" or "false"
+#   optional fixed location to query weather data about
+function fetch_weather_information() {
+  local _show_fahrenheit _location _unit
+  _show_fahrenheit="$1"
+  _location="$2"
+
+  if "$_show_fahrenheit"; then
+    _unit="u"
   else
-    echo ''
+    _unit="m"
+  fi
+
+  command -p curl -sL "${API_URL}/${_location// /%20}?format=%C${DELIM}%t${DELIM}%l&${_unit}"
+}
+
+# Format raw weather information from API
+# Globals:
+#   DELIM
+# Arguments:
+#   The raw weather data as returned by "fetch_weather_information()"
+#   show location, either "true" or "false"
+function format_weather_info() {
+  local _raw _show_location
+  _raw="$1"
+  _show_location="$2"
+
+  local _weather _temp _location
+  _weather="${_raw%%"${DELIM}"*}"  # slice temp and location to get weather
+  _temp="${_raw#*"${DELIM}"}"      # slice weather to get temp and location
+  _temp="${_temp%%"${DELIM}"*}"    # slice location to get temp
+  _temp="${_temp/+/}"              # slice "+" from "+74°F"
+  _location="${_raw##*"${DELIM}"}" # slice weather and temp to get location
+  [ "${_location//[^,]/}" == ",," ] &&
+    _location="${_location%,*}" # slice country if it exists
+
+  case "${_weather,,}" in
+  'snow')
+    _weather='❄'
+    ;;
+  'rain' | 'shower')
+    _weather='☂'
+    ;;
+  'overcast' | 'cloud')
+    _weather='☁'
+    ;;
+  'na')
+    _weather=''
+    ;;
+  *)
+    _weather='☀'
+    ;;
+  esac
+
+  if "$_show_location"; then
+    printf '%s %s %s' "$_weather" "$_temp" "$_location"
+  else
+    printf '%s %s' "$_weather" "$_temp"
   fi
 }
 
-fetch_weather_information()
-{
-  display_weather=$1
-  # it gets the weather condition textual name (%C), and the temperature (%t)
-  api_response=$(curl -sL wttr.in/${fixedlocation// /%20}\?format="%C+%t$display_weather")
+# Display weather, temperature, and location
+# Globals
+#   none
+# Arguments
+#   show fahrenheit, either "true" (default) or "false"
+#   show location, either "true" (default) or "false"
+#   optional fixed location to query data about, e.g. "Houston, Texas"
+function main() {
+  local _show_fahrenheit _show_location _location
+  _show_fahrenheit="${1:-true}"
+  _show_location="${2:-true}"
+  _location="$3"
 
-  if [[ $api_response = "Unknown location;"* ]]; then
-    echo "Unknown location error"
-  else
-    echo $api_response
-  fi
-}
-
-#get weather display
-display_weather()
-{
-  if $fahrenheit; then
-    display_weather='&u' # for USA system
-  else
-    display_weather='&m' # for metric system
-  fi
-  weather_information=$(fetch_weather_information $display_weather)
-
-  weather_condition=$(echo "$weather_information" | awk -F' -?[0-9]' '{print $1}' | xargs) # Extract condition before temperature, e.g. Sunny, Snow, etc
-  temperature=$(echo "$weather_information" | grep -oE '[-+]?[0-9]+°[CF]') # Extract temperature, e.g. +31°C, -3°F, etc
-  unicode=$(forecast_unicode $weather_condition)
-
-  # Mac Only variant should be transparent on Linux
-  if [[ "${temperature/+/}" == *"===="* ]]; then
-    temperature="error"
-  fi
-
-  if [[ "${temperature/+/}" == "error" ]]; then
-    # Propagate Error
-    echo "error"
-  else
-    echo "$unicode ${temperature/+/}" # remove the plus sign to the temperature
-  fi
-}
-
-forecast_unicode()
-{
-  weather_condition=$(echo $weather_condition | awk '{print tolower($0)}')
-
-  if [[ $weather_condition =~ 'snow' ]]; then
-    echo '❄ '
-  elif [[ (($weather_condition =~ 'rain') || ($weather_condition =~ 'shower')) ]]; then
-    echo '☂ '
-  elif [[ (($weather_condition =~ 'overcast') || ($weather_condition =~ 'cloud')) ]]; then
-    echo '☁ '
-  elif [[ $weather_condition = 'NA' ]]; then
-    echo ''
-  else
-    echo '☀ '
-  fi
-}
-
-main()
-{
   # process should be cancelled when session is killed
-  if timeout 1 bash -c "</dev/tcp/ipinfo.io/443" && timeout 1 bash -c "</dev/tcp/wttr.in/443" && [[ "$(display_weather)" != "error" ]]; then
-    echo "$(display_weather)$(display_location)"
-  else
-    echo "Weather Unavailable"
+  if ! timeout 1 bash -c "</dev/tcp/ipinfo.io/443"; then
+    printf "Weather Unavailable\n"
+    return
   fi
+
+  local _resp
+  _resp=$(fetch_weather_information "$_show_fahrenheit" "$_location")
+
+  if [[ "$_resp" = "Unknown location"* ]]; then
+    printf 'Unknown location error\n'
+  fi
+
+  format_weather_info "$_resp" "$_show_location"
 }
 
-#run main driver program
-main
+main "$@"

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -54,15 +54,15 @@ function format_weather_info() {
   _show_location="$2"
 
   local _weather _temp _location
-  _weather="${_raw%%"${DELIM}"*}"  # slice temp and location to get weather
-  _temp="${_raw#*"${DELIM}"}"      # slice weather to get temp and location
-  _temp="${_temp%%"${DELIM}"*}"    # slice location to get temp
-  _temp="${_temp/+/}"              # slice "+" from "+74°F"
-  _location="${_raw##*"${DELIM}"}" # slice weather and temp to get location
-  [ "${_location//[^,]/}" == ",," ] &&
-    _location="${_location%,*}" # slice country if it exists
+  _weather="${_raw%%"${DELIM}"*}"                                  # slice temp and location to get weather
+  _weather=$(printf '%s' "$_weather" | tr '[:upper:]' '[:lower:]') # lowercase weather, OSX’s bash3.2 does not support ${v,,}
+  _temp="${_raw#*"${DELIM}"}"                                      # slice weather to get temp and location
+  _temp="${_temp%%"${DELIM}"*}"                                    # slice location to get temp
+  _temp="${_temp/+/}"                                              # slice "+" from "+74°F"
+  _location="${_raw##*"${DELIM}"}"                                 # slice weather and temp to get location
+  [ "${_location//[^,]/}" == ",," ] && _location="${_location%,*}" # slice country if it exists
 
-  case "${_weather,,}" in
+  case "$_weather" in
   'snow')
     _weather='❄'
     ;;

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -16,6 +16,7 @@ fi
 
 # Fetch weather information from remote API
 # Globals:
+#   API_URL
 #   DELIM
 # Arguments:
 #   show fahrenheit, either "true" or "false"

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -103,6 +103,7 @@ function main() {
 
   if [[ "$_resp" = "Unknown location"* ]]; then
     printf 'Unknown location error\n'
+    return
   fi
 
   format_weather_info "$_resp" "$_show_location"

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setting the locale, some users have issues with different locales, this forces the correct one
-export LC_ALL=C.utf8
+export LC_ALL=en_US.UTF-8
 
 API_URL="https://wttr.in"
 DELIM=":"

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -50,7 +50,7 @@ function fetch_weather_information() {
 #   show location, either "true" or "false"
 function format_weather_info() {
   local _raw _show_location
-  _raw="$1"
+  _raw="$1" # e.g. "Rain:+63°F:Houston, Texas, United States"
   _show_location="$2"
 
   local _weather _temp _location

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -16,7 +16,7 @@ INTERVAL=1200
 #   show location, either "true" (default) or "false"
 #   optional fixed location to query data about, e.g. "Houston, Texas"
 function main() {
-  local _show_fahrenheit _show_location _location _current_dir _time_last
+  local _show_fahrenheit _show_location _location _current_dir _last _now
   _show_fahrenheit="$1"
   _show_location="$2"
   _location="$3"

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -25,7 +25,6 @@ function main() {
   _now=$(date +%s)
 
   if (((_now - _last) > INTERVAL)); then
-    echo updating cache
     # Run weather script here
     "${_current_dir}/weather.sh" "$_show_fahrenheit" "$_show_location" "$_location" >"${DATAFILE}"
     printf '%s' "$_now" >"${LAST_EXEC_FILE}"


### PR DESCRIPTION
## Issue

No issue submitted yet.

## Description of Changes

### General Overview
Fix Darwin timeout function duration argument. Remove unnecessary API calls to “ipinfo.io”. Confirm to Google Shell style guide and appease shellcheck.

The Darwin [timeout function](https://github.com/dracula/tmux/tree/dd1a7ab5a6e462a26723f63f968d79a4c2081510) makes use of variable `duration` which does not exist.

One execution of the `./scripts/weather.sh` makes 4 remote API calls, 2 calls to the weather service endpoint [wttr.in](https://wttr.in) and 2 calls to the geodata endpoint [ipinfo.io](https://ipinfo.io) to fetch city and region. We should make use of the first weather call for both error checking and data gathering. The calls to the geodata endpoint are not necessary as the weather endpoint provides this functionality. This change results in a single API call each script execution.

Exec's of awk, grep, and xargs should not be necessary, as bash parameter expansion allows us to extract data needed.


General style changes to conform to [Google Shell style guide](https://google.github.io/styleguide/shellguide.html), add function argument descriptions, and changes to appease shellcheck. Reduce scope of globals to local function variables.

[Shellcheck](https://github.com/koalaman/shellcheck) output
```
$ shellcheck --severity style scripts/weather*

perl -e 'alarm shift; exec @ARGV' "$duration" "$@"
^-------^ SC2154 (warning): duration is referenced but not assigned.


In scripts/weather.sh line 18:
if $location && [[ ! -z "$fixedlocation" ]]; then
^-- SC2236 (style): Use -n instead of ! -z.


In scripts/weather.sh line 33:
api_response=$(curl -sL wttr.in/${fixedlocation// /%20}\?format="%C+%t$display_weather")
^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
api_response=$(curl -sL wttr.in/"${fixedlocation// /%20}"\?format="%C+%t$display_weather")


In scripts/weather.sh line 38:
echo $api_response
^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "$api_response"


In scripts/weather.sh line 54:
unicode=$(forecast_unicode $weather_condition)
^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
unicode=$(forecast_unicode "$weather_condition")


In scripts/weather.sh line 71:
weather_condition=$(echo $weather_condition | awk '{print tolower($0)}')
^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
weather_condition=$(echo "$weather_condition" | awk '{print tolower($0)}')


In scripts/weather_wrapper.sh line 21:
if [ "$(expr ${TIME_LAST} + ${RUN_EACH})" -lt "${TIME_NOW}" ]; then
^--^ SC2003 (style): expr is antiquated. Consider rewriting this using $((..)), ${} or [[ ]].
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$(expr "${TIME_LAST}" + ${RUN_EACH})" -lt "${TIME_NOW}" ]; then


In scripts/weather_wrapper.sh line 23:
$current_dir/weather.sh $fahrenheit $location "$fixedlocation" > "${DATAFILE}"
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"$current_dir"/weather.sh "$fahrenheit" "$location" "$fixedlocation" > "${DATAFILE}"

For more information:
https://www.shellcheck.net/wiki/SC2154 -- duration is referenced but not as...
https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
https://www.shellcheck.net/wiki/SC2003 -- expr is antiquated. Consider rewr...
```


## Testing

Tested in Ubuntu as below:
```
$ ./scripts/weather.sh
☀ 70°F Houston, Texas

$ ./scripts/weather.sh true true
☀ 70°F Houston, Texas

$ ./scripts/weather.sh true false
☀ 70°F

$ ./scripts/weather.sh false false
☀ 21°C

$ ./scripts/weather.sh false true
☀ 21°C Houston, Texas

$ ./scripts/weather.sh true true "Los Angeles, California"
☀ 66°F Los Angeles, California

$ ./scripts/weather.sh true false "Los Angeles, California"
☀ 66°F

$ ./scripts/weather.sh false true "Los Angeles, California"
☀ 19°C Los Angeles, California

$ ./scripts/weather.sh "" "" "Los Angeles, California" ;echo
☀ 66°F Los Angeles, California
```
 
For the wrapper script, I manually adjusted `$INTERVAL` to 5, and added an `printf "updating cache "` to the interval condition, then:
```
$ /bin/rm /tmp/.dracula-tmux-*; ./scripts/weather_wrapper.sh true false
updating cache ☀ 70°F

$ /bin/rm /tmp/.dracula-tmux-*; ./scripts/weather_wrapper.sh false true "Los Angeles, California"
updating cache ☀ 19°C Los Angeles, California

$ /bin/rm /tmp/.dracula-tmux-*; ./scripts/weather_wrapper.sh true true "Los Angeles, California"; echo; ./scripts/weather_wrapper.sh 
updating cache ☀ 66°F Los Angeles, California
☀ 66°F Los Angeles, California

$ /bin/rm /tmp/.dracula-tmux-*; ./scripts/weather_wrapper.sh false false "Los Angeles, California"; echo; ./scripts/weather_wrapper.sh
updating cache ☀ 19°C
☀ 19°C
```

I will test on OS X tomorrow at the office.