### PR TITLE
tree: run shellharden on bash files

### DIFF
--- a/dracula.tmux
+++ b/dracula.tmux
@@ -4,5 +4,5 @@
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$current_dir/scripts/dracula.sh
+"$current_dir"/scripts/dracula.sh
 

--- a/scripts/attached_clients.sh
+++ b/scripts/attached_clients.sh
@@ -8,11 +8,11 @@ export LC_ALL=en_US.UTF-8
 # @dracula-clients-plural clients
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 count_clients() {
   pane=$(tmux list-panes -F "#{session_name}" | head -n 1)
-  tmux list-clients -t $pane | wc -l | tr -d ' '
+  tmux list-clients -t "$pane" | wc -l | tr -d ' '
 }
 
 main() {
@@ -28,7 +28,7 @@ main() {
     fi
     echo "$clients_count $clients_label"
   fi
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run main driver

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -3,13 +3,13 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 linux_acpi() {
   arg=$1
   BAT=$(ls -d /sys/class/power_supply/*)
   if [ ! -x "$(which acpi 2> /dev/null)" ];then
-    for DEV in $BAT; do
+    for DEV in "${BAT[@]}"; do
       case "$arg" in
         status)
           [ -f "$DEV/status" ] && cat "$DEV/status"
@@ -41,15 +41,15 @@ battery_percent()
   case $(uname -s) in
     Linux)
       percent=$(linux_acpi percent)
-      [ -n "$percent" ] && echo "$percent%"
+      [ "$percent" != "" ] && echo "$percent%"
       ;;
 
     Darwin)
-      echo $(pmset -g batt | grep -Eo '[0-9]?[0-9]?[0-9]%')
+      echo "$(pmset -g batt | grep -Eo '[0-9]?[0-9]?[0-9]%')"
       ;;
 
     FreeBSD)
-      echo $(apm | sed '8,11d' | grep life | awk '{print $4}')
+      echo "$(apm | sed '8,11d' | grep life | awk '{print $4}')"
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)
@@ -161,7 +161,7 @@ main()
   fi
 
   show_bat_label=$(get_tmux_option "@dracula-show-battery-status" false)
-  if $show_bat_label; then
+  if "$show_bat_label"; then
     bat_stat=$(battery_status)
   else
     bat_stat=""
@@ -169,9 +169,9 @@ main()
 
   bat_perc=$(battery_percent)
 
-  if [ -z "$bat_stat" ]; then # Test if status is empty or not
+  if [ "$bat_stat" = "" ]; then # Test if status is empty or not
     echo "$bat_label $bat_perc"
-  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
+  elif [ "$bat_perc" = "" ]; then # In case it is a desktop with no battery percent, only AC power
     echo "$no_bat_label"
   else
     echo "$bat_label$bat_stat $bat_perc"

--- a/scripts/continuum.sh
+++ b/scripts/continuum.sh
@@ -23,7 +23,7 @@ auto_save_interval_option="@continuum-save-interval"
 auto_save_interval_default="15"
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 current_timestamp() {
   echo "$(date +%s)"
@@ -73,7 +73,7 @@ set_tmux_option() {
 
 # tmux-resurrect dir
 resurrect_dir() {
-  if [ -z "$_RESURRECT_DIR" ]; then
+  if [ "$_RESURRECT_DIR" = "" ]; then
     local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir")"
     # expands tilde, $HOME and $HOSTNAME if used in @resurrect-dir
     echo "$path" | sed "s,\$HOME,$HOME,g; s,\$HOSTNAME,$(hostname),g; s,\~,$HOME,g"
@@ -92,7 +92,7 @@ last_saved_timestamp() {
   local first_save_timestamp="$(get_tmux_option "$first_save" "")"
   # continuum sets the last save timestamp to the current time on first load if auto_save_option is not set
   # so we can outrace it and detect that last_uato_save_option is empty and the timestamp is a dummy save
-  if [ -z "$first_save_timestamp" ]; then
+  if [ "$first_save_timestamp" = "" ]; then
     last_saved_timestamp="$(file_mtime "$(last_resurrect_file)")" || last_saved_timestamp=-1
     set_tmux_option "$first_save" "$last_saved_timestamp"
   elif [ "$first_save_timestamp" != "done" ]; then

--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -3,14 +3,14 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_percent()
 {
   case $(uname -s) in
     Linux)
       percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
-      normalize_percent_len $percent
+      normalize_percent_len "$percent"
       ;;
 
     Darwin)
@@ -18,7 +18,7 @@ get_percent()
       cpucores=$(sysctl -n hw.logicalcpu)
       cpuusage=$(( cpuvalue / cpucores ))
       percent="$cpuusage%"
-      normalize_percent_len $percent
+      normalize_percent_len "$percent"
       ;;
 
     OpenBSD)
@@ -26,7 +26,7 @@ get_percent()
       cpucores=$(sysctl -n hw.ncpuonline)
       cpuusage=$(( cpuvalue / cpucores ))
       percent="$cpuusage%"
-      normalize_percent_len $percent
+      normalize_percent_len "$percent"
       ;;
 
     CYGWIN*|MINGW32*|MSYS*|MINGW*)
@@ -39,7 +39,7 @@ get_load() {
   case $(uname -s) in
   Linux | Darwin | OpenBSD)
     loadavg=$(uptime | awk -F'[a-z]:' '{ print $2}' | sed 's/,//g')
-    echo $loadavg
+    echo "$loadavg"
     ;;
 
   CYGWIN* | MINGW32* | MSYS* | MINGW*)
@@ -59,7 +59,7 @@ main() {
     cpu_percent=$(get_percent)
     echo "$cpu_label $cpu_percent"
   fi
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run main driver

--- a/scripts/cwd.sh
+++ b/scripts/cwd.sh
@@ -7,7 +7,7 @@ source "$current_dir/utils.sh"
 getPaneDir() {
   nextone="false"
   ret=""
-  for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}"); do
+  for i in "$(tmux list-panes -F "#{pane_active} #{pane_current_path}")"; do
     [ "$i" == "1" ] && nextone="true" && continue
     [ "$i" == "0" ] && nextone="false"
     [ "$nextone" == "true" ] && ret+="$i "
@@ -41,7 +41,7 @@ main() {
   fi
 
   cwd_max_chars="$(get_tmux_option "@dracula-cwd-max-chars" "0")"
-  if [[ "${cwd_max_chars}" -gt 0 && "${#cwd}" -gt "$cwd_max_chars" ]]; then
+  if [[ "$cwd_max_chars" -gt 0 && "${#cwd}" -gt "$cwd_max_chars" ]]; then
     cwd="…/…${cwd:(- cwd_max_chars)}"
   fi
 

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 main() {
   # set configuration option variables
@@ -37,7 +37,7 @@ main() {
   time_format=$(get_tmux_option "@dracula-time-format" "")
   show_ssh_session_port=$(get_tmux_option "@dracula-show-ssh-session-port" false)
   show_libreview=$(get_tmux_option "@dracula-show-libreview" false)
-  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
+  IFS=' ' read -r -a plugins <<< "$(get_tmux_option "@dracula-plugins" "battery network weather")"
   show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
 
   # Dracula Color Pallette
@@ -55,14 +55,14 @@ main() {
 
   # Override default colors and possibly add more
   colors="$(get_tmux_option "@dracula-colors" "")"
-  if [ -n "$colors" ]; then
+  if [ "$colors" != "" ]; then
     eval "$colors"
   fi
 
   # Set transparency variables - Colors and window dividers
-  if $transparent_powerline_bg; then
+  if "$transparent_powerline_bg"; then
 	bg_color="default"
-	if $show_edge_icons; then
+	if "$show_edge_icons"; then
 	  window_sep_fg=${dark_purple}
 	  window_sep_bg=default
 	  window_sep="$show_right_sep"
@@ -73,7 +73,7 @@ main() {
 	fi
   else
     bg_color=${gray}
-    if $show_edge_icons; then
+    if "$show_edge_icons"; then
       window_sep_fg=${dark_purple}
       window_sep_bg=${gray}
       window_sep="$show_inverse_divider"
@@ -103,12 +103,12 @@ main() {
   # Handle left icon padding
   padding=""
   if [ "$show_left_icon_padding" -gt "0" ]; then
-    padding="$(printf '%*s' $show_left_icon_padding)"
+    padding="$(printf '%*s' "$show_left_icon_padding")"
   fi
   left_icon="$left_icon$padding"
 
   # Handle powerline option
-  if $show_powerline; then
+  if "$show_powerline"; then
     right_sep="$show_right_sep"
     left_sep="$show_left_sep"
   fi
@@ -130,13 +130,13 @@ main() {
     true)
       flags="#{?window_flags,#[fg=${dark_purple}]#{window_flags},}"
       current_flags="#{?window_flags,#[fg=${light_purple}]#{window_flags},}"
-  esac
+  ;; esac
 
   # sets refresh interval to every 5 seconds
-  tmux set-option -g status-interval $show_refresh
+  tmux set-option -g status-interval "$show_refresh"
 
   # set the prefix + t time format
-  if $show_military; then
+  if "$show_military"; then
     tmux set-option -g clock-mode-style 24
   else
     tmux set-option -g clock-mode-style 12
@@ -147,7 +147,7 @@ main() {
   tmux set-option -g status-right-length 100
 
   # pane border styling
-  if $show_border_contrast; then
+  if "$show_border_contrast"; then
     tmux set-option -g pane-active-border-style "fg=${light_purple}"
   else
     tmux set-option -g pane-active-border-style "fg=${dark_purple}"
@@ -161,8 +161,8 @@ main() {
   tmux set-option -g status-style "bg=${bg_color},fg=${white}"
 
   # Status left
-  if $show_powerline; then
-    if $show_edge_icons; then
+  if "$show_powerline"; then
+    if "$show_edge_icons"; then
       tmux set-option -g status-left "#[bg=${bg_color},fg=${green},bold]#{?client_prefix,#[fg=${yellow}],}${show_right_sep}#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${bg_color}]#{?client_prefix,#[fg=${yellow}],}${left_sep} "
     else
       tmux set-option -g status-left "#[bg=${dark_gray},fg=${green}]#[bg=${green},fg=${dark_gray}]#{?client_prefix,#[bg=${yellow}],} ${left_icon} #[fg=${green},bg=${bg_color}]#{?client_prefix,#[fg=${yellow}],}${left_sep}"
@@ -180,7 +180,7 @@ main() {
     if case $plugin in custom:*) true;; *) false;; esac; then
       script=${plugin#"custom:"}
       if [[ -x "${current_dir}/${script}" ]]; then
-        IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-custom-plugin-colors" "cyan dark_gray")
+        IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-custom-plugin-colors" "cyan dark_gray")"
         script="#($current_dir/${script})"
       else
         colors[0]="red"
@@ -188,164 +188,164 @@ main() {
         script="${script} not found!"
       fi
 
-    elif [ $plugin = "cwd" ]; then
-      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")
+    elif [ "$plugin" = "cwd" ]; then
+      IFS=' ' read -r -a colors  <<< "$(get_tmux_option "@dracula-cwd-colors" "dark_gray white")"
       tmux set-option -g status-right-length 250
       script="#($current_dir/cwd.sh)"
 
-    elif [ $plugin = "fossil" ]; then
-      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-fossil-colors" "green dark_gray")
+    elif [ "$plugin" = "fossil" ]; then
+      IFS=' ' read -r -a colors  <<< "$(get_tmux_option "@dracula-fossil-colors" "green dark_gray")"
       tmux set-option -g status-right-length 250
       script="#($current_dir/fossil.sh)"
 
-    elif [ $plugin = "git" ]; then
-      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-git-colors" "green dark_gray")
+    elif [ "$plugin" = "git" ]; then
+      IFS=' ' read -r -a colors  <<< "$(get_tmux_option "@dracula-git-colors" "green dark_gray")"
       tmux set-option -g status-right-length 250
       script="#($current_dir/git.sh)"
 
-    elif [ $plugin = "hg" ]; then
-      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-hg-colors" "green dark_gray")
+    elif [ "$plugin" = "hg" ]; then
+      IFS=' ' read -r -a colors  <<< "$(get_tmux_option "@dracula-hg-colors" "green dark_gray")"
       tmux set-option -g status-right-length 250
       script="#($current_dir/hg.sh)"
 
-    elif [ $plugin = "battery" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-battery-colors" "pink dark_gray")
+    elif [ "$plugin" = "battery" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-battery-colors" "pink dark_gray")"
       script="#($current_dir/battery.sh)"
 
-    elif [ $plugin = "gpu-usage" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-gpu-usage-colors" "pink dark_gray")
+    elif [ "$plugin" = "gpu-usage" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-gpu-usage-colors" "pink dark_gray")"
       script="#($current_dir/gpu_usage.sh)"
 
-    elif [ $plugin = "gpu-ram-usage" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-gpu-ram-usage-colors" "cyan dark_gray")
+    elif [ "$plugin" = "gpu-ram-usage" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-gpu-ram-usage-colors" "cyan dark_gray")"
       script="#($current_dir/gpu_ram_info.sh)"
 
-    elif [ $plugin = "gpu-power-draw" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-gpu-power-draw-colors" "green dark_gray")
+    elif [ "$plugin" = "gpu-power-draw" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-gpu-power-draw-colors" "green dark_gray")"
       script="#($current_dir/gpu_power.sh)"
 
-    elif [ $plugin = "cpu-usage" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-cpu-usage-colors" "orange dark_gray")
+    elif [ "$plugin" = "cpu-usage" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-cpu-usage-colors" "orange dark_gray")"
       script="#($current_dir/cpu_info.sh)"
 
-    elif [ $plugin = "ram-usage" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-ram-usage-colors" "cyan dark_gray")
+    elif [ "$plugin" = "ram-usage" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-ram-usage-colors" "cyan dark_gray")"
       script="#($current_dir/ram_info.sh)"
 
-    elif [ $plugin = "tmux-ram-usage" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-tmux-ram-usage-colors" "cyan dark_gray")
+    elif [ "$plugin" = "tmux-ram-usage" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-tmux-ram-usage-colors" "cyan dark_gray")"
       script="#($current_dir/tmux_ram_info.sh)"
 
-    elif [ $plugin = "network" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-colors" "cyan dark_gray")
+    elif [ "$plugin" = "network" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-network-colors" "cyan dark_gray")"
       script="#($current_dir/network.sh)"
 
-    elif [ $plugin = "network-bandwidth" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-network-bandwidth-colors" "cyan dark_gray")
+    elif [ "$plugin" = "network-bandwidth" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-network-bandwidth-colors" "cyan dark_gray")"
       tmux set-option -g status-right-length 250
       script="#($current_dir/network_bandwidth.sh)"
 
-    elif [ $plugin = "network-ping" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-network-ping-colors" "cyan dark_gray")
+    elif [ "$plugin" = "network-ping" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-network-ping-colors" "cyan dark_gray")"
       script="#($current_dir/network_ping.sh)"
 
-    elif [ $plugin = "network-vpn" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-network-vpn-colors" "cyan dark_gray")
+    elif [ "$plugin" = "network-vpn" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-network-vpn-colors" "cyan dark_gray")"
       script="#($current_dir/network_vpn.sh)"
 
-    elif [ $plugin = "attached-clients" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-attached-clients-colors" "cyan dark_gray")
+    elif [ "$plugin" = "attached-clients" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-attached-clients-colors" "cyan dark_gray")"
       script="#($current_dir/attached_clients.sh)"
 
-    elif [ $plugin = "mpc" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-mpc-colors" "green dark_gray")
+    elif [ "$plugin" = "mpc" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-mpc-colors" "green dark_gray")"
       script="#($current_dir/mpc.sh)"
 
-    elif [ $plugin = "spotify-tui" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")
+    elif [ "$plugin" = "spotify-tui" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-spotify-tui-colors" "green dark_gray")"
       script="#($current_dir/spotify-tui.sh)"
 
-    elif [ $plugin = "krbtgt" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-krbtgt-colors" "cyan dark_gray")
+    elif [ "$plugin" = "krbtgt" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-krbtgt-colors" "cyan dark_gray")"
       script="#($current_dir/krbtgt.sh $krbtgt_principal $show_krbtgt_label)"
 
-    elif [ $plugin = "playerctl" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-playerctl-colors" "green dark_gray")
+    elif [ "$plugin" = "playerctl" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-playerctl-colors" "green dark_gray")"
       script="#($current_dir/playerctl.sh)"
 
-    elif [ $plugin = "kubernetes-context" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")
+    elif [ "$plugin" = "kubernetes-context" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-kubernetes-context-colors" "cyan dark_gray")"
       script="#($current_dir/kubernetes_context.sh $eks_hide_arn $eks_extract_account $hide_kubernetes_user $show_only_kubernetes_context $show_kubernetes_context_label)"
 
-    elif [ $plugin = "terraform" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-terraform-colors" "light_purple dark_gray")
+    elif [ "$plugin" = "terraform" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-terraform-colors" "light_purple dark_gray")"
       script="#($current_dir/terraform.sh $terraform_label)"
 
-    elif [ $plugin = "continuum" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-continuum-colors" "cyan dark_gray")
+    elif [ "$plugin" = "continuum" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-continuum-colors" "cyan dark_gray")"
       script="#($current_dir/continuum.sh)"
 
-    elif [ $plugin = "weather" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-weather-colors" "orange dark_gray")
+    elif [ "$plugin" = "weather" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-weather-colors" "orange dark_gray")"
       script="#($current_dir/weather_wrapper.sh $show_fahrenheit $show_location '$fixed_location')"
 
-    elif [ $plugin = "time" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-time-colors" "dark_purple white")
-      if [ -n "$time_format" ]; then
+    elif [ "$plugin" = "time" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-time-colors" "dark_purple white")"
+      if [ "$time_format" != "" ]; then
         script=${time_format}
       else
-        if $show_day_month && $show_military ; then # military time and dd/mm
+        if "$show_day_month" && "$show_military" ; then # military time and dd/mm
           script="%a %d/%m %R ${timezone} "
-        elif $show_military; then # only military time
+        elif "$show_military"; then # only military time
           script="%R ${timezone} "
-        elif $show_day_month; then # only dd/mm
+        elif "$show_day_month"; then # only dd/mm
           script="%a %d/%m %I:%M %p ${timezone} "
         else
           script="%a %m/%d %I:%M %p ${timezone} "
         fi
       fi
-    elif [ $plugin = "synchronize-panes" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-synchronize-panes-colors" "cyan dark_gray")
+    elif [ "$plugin" = "synchronize-panes" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-synchronize-panes-colors" "cyan dark_gray")"
       script="#($current_dir/synchronize_panes.sh $show_synchronize_panes_label)"
 
-    elif [ $plugin = "libreview" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-libre-colors" "white dark_gray")
+    elif [ "$plugin" = "libreview" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-libre-colors" "white dark_gray")"
       script="#($current_dir/libre.sh $show_libreview)"
 
-    elif [ $plugin = "ssh-session" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-ssh-session-colors" "green dark_gray")
+    elif [ "$plugin" = "ssh-session" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-ssh-session-colors" "green dark_gray")"
       script="#($current_dir/ssh_session.sh $show_ssh_session_port)"
 
-    elif [ $plugin = "network-public-ip" ]; then
-      IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-network-public-ip-colors" "cyan dark_gray")
+    elif [ "$plugin" = "network-public-ip" ]; then
+      IFS=' ' read -r -a colors <<<"$(get_tmux_option "@dracula-network-public-ip-colors" "cyan dark_gray")"
       script="#($current_dir/network-public-ip.sh)"
 
     else
       continue
     fi
 
-    if [ $plugin = "sys-temp" ]; then
-      IFS=' ' read -r -a colors <<< $(get_tmux_option "@dracula-sys-temp-colors" "green dark_gray")
+    if [ "$plugin" = "sys-temp" ]; then
+      IFS=' ' read -r -a colors <<< "$(get_tmux_option "@dracula-sys-temp-colors" "green dark_gray")"
       script="#($current_dir/sys_temp.sh)"
     fi
 
     # edge styling
-    if $show_edge_icons; then
+    if "$show_edge_icons"; then
       right_edge_icon="#[bg=${bg_color},fg=${!colors[0]}]${show_left_sep}"
       background_color=${bg_color}
     else
       background_color=${powerbg}
     fi
 
-    if $show_powerline; then
-      if $show_empty_plugins; then
+    if "$show_powerline"; then
+      if "$show_empty_plugins"; then
         tmux set-option -ga status-right " #[fg=${!colors[0]},bg=${background_color},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script $right_edge_icon"
       else
     tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[0]},nobold,nounderscore,noitalics] ${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script $right_edge_icon}"
     fi
       powerbg=${!colors[0]}
     else
-      if $show_empty_plugins; then
+      if "$show_empty_plugins"; then
         tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script "
       else
         tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[1]},bg=${!colors[0]}] $script }"
@@ -355,7 +355,7 @@ main() {
   done
 
   # Window option
-  if $show_powerline; then
+  if "$show_powerline"; then
     tmux set-window-option -g window-status-current-format "#[fg=${window_sep_fg},bg=${window_sep_bg}]${window_sep}#[fg=${white},bg=${dark_purple}] #I #W${current_flags} #[fg=${dark_purple},bg=${bg_color}]${left_sep}"
   else
     tmux set-window-option -g window-status-current-format "#[fg=${white},bg=${dark_purple}] #I #W${current_flags} "

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
-IFS=' ' read -r -a hide_status <<< $(get_tmux_option "@dracula-git-disable-status" "false")
-IFS=' ' read -r -a current_symbol <<< $(get_tmux_option "@dracula-git-show-current-symbol" "✓")
-IFS=' ' read -r -a diff_symbol <<< $(get_tmux_option "@dracula-git-show-diff-symbol" "!")
-IFS=' ' read -r -a no_repo_message <<< $(get_tmux_option "@dracula-git-no-repo-message" "")
-IFS=' ' read -r -a no_untracked_files <<< $(get_tmux_option "@dracula-git-no-untracked-files" "false")
-IFS=' ' read -r -a show_remote_status <<< $(get_tmux_option "@dracula-git-show-remote-status" "false")
+IFS=' ' read -r -a hide_status <<< "$(get_tmux_option "@dracula-git-disable-status" "false")"
+IFS=' ' read -r -a current_symbol <<< "$(get_tmux_option "@dracula-git-show-current-symbol" "✓")"
+IFS=' ' read -r -a diff_symbol <<< "$(get_tmux_option "@dracula-git-show-diff-symbol" "!")"
+IFS=' ' read -r -a no_repo_message <<< "$(get_tmux_option "@dracula-git-no-repo-message" "")"
+IFS=' ' read -r -a no_untracked_files <<< "$(get_tmux_option "@dracula-git-no-untracked-files" "false")"
+IFS=' ' read -r -a show_remote_status <<< "$(get_tmux_option "@dracula-git-show-remote-status" "false")"
 
 # Get added, modified, updated and deleted files from git status
 getChanges()
@@ -18,18 +18,18 @@ getChanges()
    declare -i updated=0;
    declare -i deleted=0;
 
-for i in $(git -C $path --no-optional-locks status -s)
+for i in "$(git -C "$path" --no-optional-locks status -s)"
 
     do
-      case $i in 
+      case $i in
       'A')
-        added+=1 
+        added+=1
       ;;
       'M')
         modified+=1
       ;;
       'U')
-        updated+=1 
+        updated+=1
       ;;
       'D')
        deleted+=1
@@ -39,12 +39,12 @@ for i in $(git -C $path --no-optional-locks status -s)
     done
 
     output=""
-    [ $added -gt 0 ] && output+="${added}A"
-    [ $modified -gt 0 ] && output+=" ${modified}M"
-    [ $updated -gt 0 ] && output+=" ${updated}U"
-    [ $deleted -gt 0 ] && output+=" ${deleted}D"
-  
-    echo $output    
+    [ "$added" -gt 0 ] && output+="${added}A"
+    [ "$modified" -gt 0 ] && output+=" ${modified}M"
+    [ "$updated" -gt 0 ] && output+=" ${updated}U"
+    [ "$deleted" -gt 0 ] && output+=" ${deleted}D"
+
+    echo "$output"
 }
 
 
@@ -52,12 +52,12 @@ for i in $(git -C $path --no-optional-locks status -s)
 getPaneDir()
 {
  nextone="false"
- for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
+ for i in "$(tmux list-panes -F "#{pane_active} #{pane_current_path}")";
  do
     if [ "$nextone" == "true" ]; then
-       echo $i
+       echo "$i"
        return
-    fi 
+    fi
     if [ "$i" == "1" ]; then
         nextone="true"
     fi
@@ -68,7 +68,7 @@ getPaneDir()
 # check if the current or diff symbol is empty to remove ugly padding
 checkEmptySymbol()
 {
-    symbol=$1    
+    symbol=$1
     if [ "$symbol" == "" ]; then
         echo "true"
     else
@@ -79,9 +79,9 @@ checkEmptySymbol()
 # check to see if the current repo is not up to date with HEAD
 checkForChanges()
 {
-    [ $no_untracked_files == "false" ] && no_untracked="" || no_untracked="-uno"
+    [ "$no_untracked_files" == "false" ] && no_untracked="" || no_untracked="-uno"
     if [ "$(checkForGitDir)" == "true" ]; then
-        if [ "$(git -C $path --no-optional-locks status -s $no_untracked)" != "" ]; then
+        if [ "$(git -C "$path" --no-optional-locks status -s "$no_untracked")" != "" ]; then
             echo "true"
         else
             echo "false"
@@ -89,12 +89,12 @@ checkForChanges()
     else
         echo "false"
     fi
-}     
+}
 
 # check if a git repo exists in the directory
 checkForGitDir()
 {
-    if [ "$(git -C $path rev-parse --abbrev-ref HEAD)" != "" ]; then
+    if [ "$(git -C "$path" rev-parse --abbrev-ref HEAD)" != "" ]; then
         echo "true"
     else
         echo "false"
@@ -103,27 +103,27 @@ checkForGitDir()
 
 # return branch name if there is one
 getBranch()
-{   
-    if [ $(checkForGitDir) == "true" ]; then
-        echo $(git -C $path rev-parse --abbrev-ref HEAD)
+{
+    if [ "$(checkForGitDir)" == "true" ]; then
+        echo "$(git -C "$path" rev-parse --abbrev-ref HEAD)"
     else
-        echo $no_repo_message
+        echo "$no_repo_message"
     fi
 }
 
 getRemoteInfo()
 {
-    base=$(git -C $path for-each-ref --format='%(upstream:short) %(upstream:track)' "$(git -C $path symbolic-ref -q HEAD)")
+    base=$(git -C "$path" for-each-ref --format='%(upstream:short) %(upstream:track)' "$(git -C "$path" symbolic-ref -q HEAD)")
     remote=$(echo "$base" | cut -d" " -f1)
     out=""
 
-    if [ -n "$remote" ]; then
+    if [ "$remote" != "" ]; then
         out="...$remote"
         ahead=$(echo "$base" | grep -E -o 'ahead[ [:digit:]]+' | cut -d" " -f2)
         behind=$(echo "$base" | grep -E -o 'behind[ [:digit:]]+' | cut -d" " -f2)
 
-        [ -n "$ahead" ] && out+=" +$ahead"
-        [ -n "$behind" ] && out+=" -$behind"
+        [ "$ahead" != "" ] && out+=" +$ahead"
+        [ "$behind" != "" ] && out+=" -$behind"
     fi
 
     echo "$out"
@@ -132,22 +132,22 @@ getRemoteInfo()
 # return the final message for the status bar
 getMessage()
 {
-    if [ $(checkForGitDir) == "true" ]; then
+    if [ "$(checkForGitDir)" == "true" ]; then
         branch="$(getBranch)"
         output=""
 
-        if [ $(checkForChanges) == "true" ]; then 
-            
-            changes="$(getChanges)" 
-            
-            if [ "${hide_status}" == "false" ]; then
-                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+        if [ "$(checkForChanges)" == "true" ]; then
+
+            changes="$(getChanges)"
+
+            if [ "$hide_status" == "false" ]; then
+                if [ "$(checkEmptySymbol "$diff_symbol")" == "true" ]; then
 		     output=$(echo "${changes} $branch")
                 else
 		     output=$(echo "$diff_symbol ${changes} $branch")
                 fi
             else
-                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+                if [ "$(checkEmptySymbol "$diff_symbol")" == "true" ]; then
 		     output=$(echo "$branch")
                 else
 		     output=$(echo "$diff_symbol $branch")
@@ -155,7 +155,7 @@ getMessage()
             fi
 
         else
-            if [ $(checkEmptySymbol $current_symbol) == "true" ]; then
+            if [ "$(checkEmptySymbol "$current_symbol")" == "true" ]; then
 	         output=$(echo "$branch")
             else
 		 output=$(echo "$current_symbol $branch")
@@ -165,15 +165,15 @@ getMessage()
         [ "$show_remote_status" == "true" ] && output+=$(getRemoteInfo)
         echo "$output"
     else
-        echo $no_repo_message
+        echo "$no_repo_message"
     fi
 }
 
 main()
-{  
+{
     path=$(getPaneDir)
     getMessage
 }
 
 #run main driver program
-main 
+main

--- a/scripts/gpu_power.sh
+++ b/scripts/gpu_power.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_platform()
 {
@@ -12,13 +12,13 @@ get_platform()
       # use this option for when your gpu isn't detected
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
-        echo $gpu_label
+        echo "$gpu_label"
       else
         # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
         if [[ -n $gpu ]]; then
           # if a gpu is detected, return it
-          echo $gpu
+          echo "$gpu"
         elif type -a nvidia-smi >> /dev/null; then
           # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
           echo "NVIDIA"
@@ -43,7 +43,7 @@ get_gpu()
   gpu=$(get_platform)
   gpu_power_percent=$(get_tmux_option "@dracula-gpu-power-percent" false)
   if [[ "$gpu" == NVIDIA ]]; then
-    if $gpu_power_percent; then
+    if "$gpu_power_percent"; then
       usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%d%%\n", draw / max * 100) }')
   else
       usage=$(nvidia-smi --query-gpu=power.draw,power.limit --format=csv,noheader,nounits | awk '{ draw += $0; max +=$2 } END { printf("%dW/%dW\n", draw, max) }')
@@ -54,7 +54,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  normalize_percent_len "$usage"
 }
 
 main()
@@ -64,7 +64,7 @@ main()
   gpu_label=$(get_tmux_option "@dracula-gpu-power-label" "GPU")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run the main driver

--- a/scripts/gpu_ram_info.sh
+++ b/scripts/gpu_ram_info.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_platform()
 {
@@ -12,13 +12,13 @@ get_platform()
       # use this option for when your gpu isn't detected
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
-        echo $gpu_label
+        echo "$gpu_label"
       else
         # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
         if [[ -n $gpu ]]; then
           # if a gpu is detected, return it
-          echo $gpu
+          echo "$gpu"
         elif type -a nvidia-smi >> /dev/null; then
           # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
           echo "NVIDIA"
@@ -41,9 +41,9 @@ get_gpu()
   gpu=$(get_platform)
   gpu_vram_percent=$(get_tmux_option "@dracula-gpu-vram-percent" false)
   if [[ "$gpu" == NVIDIA ]]; then
-    if $gpu_vram_percent; then
+    if "$gpu_vram_percent"; then
       usage=$(nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | awk '{ used += $0; total +=$2 } END { printf("%d%%\n", used / total * 100 ) }')
-    normalize_percent_len $usage
+    normalize_percent_len "$usage"
     exit 0
     else
       # to add finer grained info
@@ -54,7 +54,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  echo $usage
+  echo "$usage"
 }
 
 main()
@@ -64,7 +64,7 @@ main()
   gpu_label=$(get_tmux_option "@dracula-gpu-vram-label" "VRAM")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run the main driver

--- a/scripts/gpu_usage.sh
+++ b/scripts/gpu_usage.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_platform()
 {
@@ -12,13 +12,13 @@ get_platform()
       # use this option for when your gpu isn't detected
       gpu_label=$(get_tmux_option "@dracula-force-gpu" false)
       if [[ "$gpu_label" != false ]]; then
-        echo $gpu_label
+        echo "$gpu_label"
       else
         # attempt to detect the gpu
         gpu=$(lspci -v | grep VGA | head -n 1 | awk '{print $5}')
         if [[ -n $gpu ]]; then
           # if a gpu is detected, return it
-          echo $gpu
+          echo "$gpu"
         elif type -a nvidia-smi >> /dev/null; then
           # if no gpu was detected, and nvidia-smi is installed, we'll still try nvidia
           echo "NVIDIA"
@@ -49,7 +49,7 @@ get_gpu()
   else
     usage='unknown'
   fi
-  normalize_percent_len $usage
+  normalize_percent_len "$usage"
 }
 
 main()
@@ -59,7 +59,7 @@ main()
   gpu_label=$(get_tmux_option "@dracula-gpu-usage-label" "GPU")
   gpu_usage=$(get_gpu)
   echo "$gpu_label $gpu_usage"
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run the main driver

--- a/scripts/hg.sh
+++ b/scripts/hg.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
-IFS=' ' read -r -a hide_status <<< $(get_tmux_option "@dracula-hg-disable-status" "false")
-IFS=' ' read -r -a current_symbol <<< $(get_tmux_option "@dracula-hg-show-current-symbol" "✓")
-IFS=' ' read -r -a diff_symbol <<< $(get_tmux_option "@dracula-hg-show-diff-symbol" "!")
-IFS=' ' read -r -a no_repo_message <<< $(get_tmux_option "@dracula-hg-no-repo-message" "")
-IFS=' ' read -r -a no_untracked_files <<< $(get_tmux_option "@dracula-hg-no-untracked-files" "false")
+IFS=' ' read -r -a hide_status <<< "$(get_tmux_option "@dracula-hg-disable-status" "false")"
+IFS=' ' read -r -a current_symbol <<< "$(get_tmux_option "@dracula-hg-show-current-symbol" "✓")"
+IFS=' ' read -r -a diff_symbol <<< "$(get_tmux_option "@dracula-hg-show-diff-symbol" "!")"
+IFS=' ' read -r -a no_repo_message <<< "$(get_tmux_option "@dracula-hg-no-repo-message" "")"
+IFS=' ' read -r -a no_untracked_files <<< "$(get_tmux_option "@dracula-hg-no-untracked-files" "false")"
 
 # Get added, modified, and removed files from hg status
 getChanges()
@@ -18,7 +18,7 @@ getChanges()
    declare -i removed=0;
    declare -i untracked=0;
 
-for i in $(hg -R $path status -admru)
+for i in "$(hg -R "$path" status -admru)"
     do
       case $i in
       'A')
@@ -41,13 +41,13 @@ for i in $(hg -R $path status -admru)
     done
 
     output=""
-    [ $added -gt 0 ] && output+="${added}A"
-    [ $modified -gt 0 ] && output+=" ${modified}M"
-    [ $deleted -gt 0 ] && output+=" ${deleted}D"
-    [ $removed -gt 0 ] && output+=" ${removed}R"
-    [ $no_untracked_files == "false" -a $untracked -gt 0 ] && output+=" ${untracked}?"
+    [ "$added" -gt 0 ] && output+="${added}A"
+    [ "$modified" -gt 0 ] && output+=" ${modified}M"
+    [ "$deleted" -gt 0 ] && output+=" ${deleted}D"
+    [ "$removed" -gt 0 ] && output+=" ${removed}R"
+    [ "$no_untracked_files" == "false" -a "$untracked" -gt 0 ] && output+=" ${untracked}?"
 
-    echo $output
+    echo "$output"
 }
 
 
@@ -55,10 +55,10 @@ for i in $(hg -R $path status -admru)
 getPaneDir()
 {
  nextone="false"
- for i in $(tmux list-panes -F "#{pane_active} #{pane_current_path}");
+ for i in "$(tmux list-panes -F "#{pane_active} #{pane_current_path}")";
  do
     if [ "$nextone" == "true" ]; then
-       echo $i
+       echo "$i"
        return
     fi
     if [ "$i" == "1" ]; then
@@ -82,9 +82,9 @@ checkEmptySymbol()
 # check to see if the current repo is not up to date with HEAD
 checkForChanges()
 {
-    [ $no_untracked_files == "false" ] && no_untracked="-u" || no_untracked=""
+    [ "$no_untracked_files" == "false" ] && no_untracked="-u" || no_untracked=""
     if [ "$(checkForHgDir)" == "true" ]; then
-        if [ "$(hg -R $path status -admr $no_untracked)" != "" ]; then
+        if [ "$(hg -R "$path" status -admr "$no_untracked")" != "" ]; then
             echo "true"
         else
             echo "false"
@@ -97,7 +97,7 @@ checkForChanges()
 # check if a hg repo exists in the directory
 checkForHgDir()
 {
-    if [ "$(hg -R $path branch)" != "" ]; then
+    if [ "$(hg -R "$path" branch)" != "" ]; then
         echo "true"
     else
         echo "false"
@@ -107,32 +107,32 @@ checkForHgDir()
 # return branch name if there is one
 getBranch()
 {
-    if [ $(checkForHgDir) == "true" ]; then
-        echo $(hg -R $path branch)
+    if [ "$(checkForHgDir)" == "true" ]; then
+        echo "$(hg -R "$path" branch)"
     else
-        echo $no_repo_message
+        echo "$no_repo_message"
     fi
 }
 
 # return the final message for the status bar
 getMessage()
 {
-    if [ $(checkForHgDir) == "true" ]; then
+    if [ "$(checkForHgDir)" == "true" ]; then
         branch="$(getBranch)"
         output=""
 
-        if [ $(checkForChanges) == "true" ]; then
+        if [ "$(checkForChanges)" == "true" ]; then
 
             changes="$(getChanges)"
 
-            if [ "${hide_status}" == "false" ]; then
-                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+            if [ "$hide_status" == "false" ]; then
+                if [ "$(checkEmptySymbol "$diff_symbol")" == "true" ]; then
 		     output=$(echo "${changes} $branch")
                 else
 		     output=$(echo "$diff_symbol ${changes} $branch")
                 fi
             else
-                if [ $(checkEmptySymbol $diff_symbol) == "true" ]; then
+                if [ "$(checkEmptySymbol "$diff_symbol")" == "true" ]; then
 		     output=$(echo "$branch")
                 else
 		     output=$(echo "$diff_symbol $branch")
@@ -140,7 +140,7 @@ getMessage()
             fi
 
         else
-            if [ $(checkEmptySymbol $current_symbol) == "true" ]; then
+            if [ "$(checkEmptySymbol "$current_symbol")" == "true" ]; then
 	         output=$(echo "$branch")
             else
 		 output=$(echo "$current_symbol $branch")
@@ -149,7 +149,7 @@ getMessage()
 
         echo "$output"
     else
-        echo $no_repo_message
+        echo "$no_repo_message"
     fi
 }
 

--- a/scripts/krbtgt.sh
+++ b/scripts/krbtgt.sh
@@ -6,16 +6,16 @@ principal=$1
 label=$2
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
-if [ -n "$principal" ]; then
+if [ "$principal" != "" ]; then
   _principal=$principal
   if ! [[ "$_principal" =~ "@" ]]; then
     _principal="$_principal@"
   fi
   krb_principal_tgt_cache=$(klist -lan | awk -v krb_principal="^$_principal" '$0 ~ krb_principal {print $2}')
-  if [ -n "$krb_principal_tgt_cache" ]; then
-    krb_tgt_expire=$(date '+%H:%M:%S' -d "$(klist $krb_principal_tgt_cache | awk '/krbtgt/ {print $3,$4}')")
+  if [ "$krb_principal_tgt_cache" != "" ]; then
+    krb_tgt_expire=$(date '+%H:%M:%S' -d "$(klist "$krb_principal_tgt_cache" | awk '/krbtgt/ {print $3,$4}')")
   else
     krb_tgt_expire=""
   fi
@@ -26,23 +26,23 @@ main()
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   OUTPUT_STRING=""
-  if [ -z "$principal" ]; then
+  if [ "$principal" = "" ]; then
     OUTPUT_STRING="no principal configured"
   fi
 
-  if [ -z "$krb_tgt_expire" ]; then
+  if [ "$krb_tgt_expire" = "" ]; then
       OUTPUT_STRING="$principal -"
   else
       OUTPUT_STRING="${principal} ${krb_tgt_expire}"
   fi
 
   if [ "$label" = "" ]; then
-    echo "${OUTPUT_STRING}"
+    echo "$OUTPUT_STRING"
   else
     echo "${label} ${OUTPUT_STRING}"
   fi
 
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run the main driver

--- a/scripts/kubernetes_context.sh
+++ b/scripts/kubernetes_context.sh
@@ -9,12 +9,12 @@ just_current_context=$4
 label=$5
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 current_context=$(kubectl config view --minify --output 'jsonpath={.current-context}'; echo)
-current_user=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.user}'; echo)
-current_cluster=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.cluster}'; echo)
-current_namespace=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'$current_context'")].context.namespace}'; echo)
+current_user=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'"$current_context"'")].context.user}'; echo)
+current_cluster=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'"$current_context"'")].context.cluster}'; echo)
+current_namespace=$(kubectl config view --minify --output 'jsonpath={.contexts[?(@.name=="'"$current_context"'")].context.namespace}'; echo)
 
 current_account_id=""
 if [[ "$current_cluster" =~ ^arn:(aws|aws-[a-z\-]*-gov):eks:[a-z0-9\-]*:[0-9]*:cluster/[a-z0-9\-]*$ ]]; then
@@ -43,7 +43,7 @@ main()
     getFullMessage
   fi
 
-  sleep $RATE
+  sleep "$RATE"
 }
 
 getFullMessage()
@@ -75,7 +75,7 @@ getFullMessage()
 
   if [ "$label" = "" ]
   then
-    echo "${OUTPUT_STRING}"
+    echo "$OUTPUT_STRING"
   else
     echo "${label} ${OUTPUT_STRING}"
   fi

--- a/scripts/libre.sh
+++ b/scripts/libre.sh
@@ -44,7 +44,7 @@ export LC_ALL=en_US.UTF-8
 
 # Load utils
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 # Constants (Default values, can be overridden by config)
 BASE_URL="${LIBREVIEW_API_URL:-https://api-de.libreview.io}"
@@ -95,7 +95,7 @@ get_file_size()
 rotate_log() {
     if [ -f "$LOG_FILE" ]; then
         log_size=$(get_file_size "$LOG_FILE")
-        if [ "$log_size" -gt $LOG_MAX_SIZE ]; then
+        if [ "$log_size" -gt "$LOG_MAX_SIZE" ]; then
             mv "$LOG_FILE" "$LOG_FILE.1"
             gzip "$LOG_FILE.1"
         fi
@@ -132,7 +132,7 @@ EOL
     : "${LOG_FILE:=$LOG_FILE}"
     : "${LOG_MAX_SIZE:=$LOG_MAX_SIZE}"
 
-    if [ -z "$LIBREVIEW_EMAIL" ] || [ -z "$LIBREVIEW_PASSWORD" ]; then
+    if [ "$LIBREVIEW_EMAIL" = "" ] || [ "$LIBREVIEW_PASSWORD" = "" ]; then
         if grep -q '^[^#]' "$CONFIG_FILE"; then
             log "Email and password must be set in the configuration file"
             echo "🦋 CHECK CONFIG ❌"
@@ -179,7 +179,7 @@ login() {
     response=$(echo "$response" | tr -d '\0' | tr -cd '\11\12\15\40-\176')
     token=$(echo "$response" | jq -r '.data.authTicket.token' 2>/dev/null)
     expires=$(echo "$response" | jq -r '.data.authTicket.expires' 2>/dev/null)
-    if [ -z "$token" ] || [ "$token" == "null" ]; then
+    if [ "$token" = "" ] || [ "$token" == "null" ]; then
         log "Failed to retrieve token from login response"
         echo "🦋 NO DATA ❌"
         exit 1
@@ -209,7 +209,7 @@ get_patient_connections() {
     log "Patient connections response: $response"
 
     data=$(echo "$response" | jq -c '.data' 2>/dev/null)
-    if [ -z "$data" ] || [ "$data" == "null" ]; then
+    if [ "$data" = "" ] || [ "$data" == "null" ]; then
         log "No patient connections found"
         echo "🦋 NO DATA ❌"
         exit 1
@@ -316,7 +316,7 @@ get_data() {
         fi
 
         patient_id=$(echo "$patient_data" | jq -r '.[0].patientId' 2>/dev/null)
-        if [ -z "$patient_id" ];then
+        if [ "$patient_id" = "" ];then
             log "Patient ID not found in patient connections"
             echo "🦋 NO DATA ❌"
             exit 1

--- a/scripts/mpc.sh
+++ b/scripts/mpc.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 main()
 {
@@ -16,8 +16,8 @@ main()
   fi
 
   FORMAT=$(get_tmux_option "@dracula-mpc-format" "%title% - %artist%")
-  mpc_playback=$(mpc current -f "${FORMAT}")
-  echo ${mpc_playback}
+  mpc_playback=$(mpc current -f "$FORMAT")
+  echo "$mpc_playback"
 
 }
 

--- a/scripts/network-public-ip.sh
+++ b/scripts/network-public-ip.sh
@@ -4,7 +4,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 main() {
   IP_SERVER="ifconfig.me"

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 # set your own hosts so that a wifi is recognised even without internet access
 HOSTS=$(get_tmux_option "@dracula-network-hosts" "google.com github.com example.com")
@@ -16,7 +16,7 @@ get_ssid()
   case $(uname -s) in
     Linux)
       SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
-      if [ -n "$SSID" ]; then
+      if [ "$SSID" != "" ]; then
         echo "$wifi_label$SSID"
       else
         echo "$ethernet_label"
@@ -49,7 +49,7 @@ get_ssid()
 main()
 {
   network="$(get_tmux_option "@dracula-network-offline-label" "Offline")"
-  for host in $HOSTS; do
+  for host in "${HOSTS[@]}"; do
     if ping -q -c 1 -W 1 "$host" &>/dev/null; then
       network="$(get_ssid)"
       break

--- a/scripts/network_bandwidth.sh
+++ b/scripts/network_bandwidth.sh
@@ -112,7 +112,7 @@ main() {
     IFS=" " read -ra bandwidth <<<"$(get_bandwidth "$network_name")"
 
     if [[ $show_interface == "true" ]]; then echo -n "[$network_name] "; fi
-    printf "↓ %6s %-4s • ↑ %6s %-4s\n" $(bandwidth_to_unit "${bandwidth[$DOWNLOAD]}") $(bandwidth_to_unit "${bandwidth[$UPLOAD]}")
+    printf "↓ %6s %-4s • ↑ %6s %-4s\n" "$(bandwidth_to_unit "${bandwidth[$DOWNLOAD]}")" "$(bandwidth_to_unit "${bandwidth[$UPLOAD]}")"
 
     ((counter = counter - 1))
     sleep "$interval_update"

--- a/scripts/network_ping.sh
+++ b/scripts/network_ping.sh
@@ -7,7 +7,7 @@ export LC_ALL=en_US.UTF-8
 # @dracula-ping-rate 5
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 ping_function() {
   case $(uname -s) in
@@ -26,9 +26,9 @@ ping_function() {
 
 main() {
 
-  echo $(ping_function)
+  echo "$(ping_function)"
   RATE=$(get_tmux_option "@dracula-ping-rate" 5)
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run main driver

--- a/scripts/network_vpn.sh
+++ b/scripts/network_vpn.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 vpn_function() {
   case $(uname -s) in
@@ -12,7 +12,7 @@ vpn_function() {
     vpn=$(ip -o -4 addr show dev tun0 | awk '{print $4}' | cut -d/ -f1)
 
     if [[ $vpn =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-      echo $vpn
+      echo "$vpn"
     else
       echo "NO VPN"
     fi
@@ -21,7 +21,7 @@ vpn_function() {
   Darwin)
     vpn=$(scutil --nc list | grep Connected)
 
-    if [ -z $vpn ]; then
+    if [ "$vpn" = "" ]; then
       echo ""
     else
       echo "VPN"
@@ -36,7 +36,7 @@ vpn_function() {
 
 main() {
 
-  echo $(vpn_function)
+  echo "$(vpn_function)"
 }
 
 # run main driver

--- a/scripts/playerctl.sh
+++ b/scripts/playerctl.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 function slice_loop() {
   local str="$1"
@@ -31,7 +31,7 @@ main() {
   fi
 
   FORMAT=$(get_tmux_option "@dracula-playerctl-format" "Now playing: {{ artist }} - {{ album }} - {{ title }}")
-  playerctl_playback=$(playerctl metadata --format "${FORMAT}")
+  playerctl_playback=$(playerctl metadata --format "$FORMAT")
   playerctl_playback="${playerctl_playback} "
 
   # Adjust width of string

--- a/scripts/ram_info.sh
+++ b/scripts/ram_info.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_ratio()
 {
@@ -18,7 +18,7 @@ get_ratio()
 
     Darwin)
       # Get used memory blocks with vm_stat, multiply by page size to get size in bytes, then convert to MiB
-      used_mem=$(vm_stat | grep ' active\|wired\|compressor\|speculative' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2+$3+$5) * pagesize / 1048576}')
+      used_mem=$(vm_stat | grep ' active\|wired\|compressor\|speculative' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize="$(pagesize)" '{printf "%d\n", ($1+$2+$3+$5) * pagesize / 1048576}')
       # System Profiler performs an activation lock check, which can result in
       # time outs or a lagged response. (~10 seconds)
       # total_mem=$(system_profiler SPHardwareDataType | grep "Memory:" | awk '{print $2 $3}')
@@ -41,7 +41,7 @@ get_ratio()
       free_mem=$(((mem_inactive + mem_unused + mem_cache) / 1024 / 1024))
       total_mem=$(($(sysctl -n hw.physmem) / 1024 / 1024))
       used_mem=$((total_mem - free_mem))
-      echo $used_mem
+      echo "$used_mem"
       if ((used_mem < 1024 )); then
         echo "${used_mem}MB/$total_mem"
       else
@@ -64,10 +64,10 @@ $(vmstat -s | grep "pages zeroed$" | sed -ne 's/^ *\([0-9]*\).*$/\1/p') +
       #used_mem=$((total_mem - free_mem))
       total_mem=$(($total_mem/1024))
       if (( $used_mem < 1024 )); then
-        echo $used_mem\M\B/$total_mem\G\B
+        echo "$used_mem"\M\B/"$total_mem"\G\B
       else
         memory=$(($used_mem/1024))
-        echo $memory\G\B/$total_mem\G\B
+        echo "$memory"\G\B/"$total_mem"\G\B
       fi
       ;;
 

--- a/scripts/spotify-tui.sh
+++ b/scripts/spotify-tui.sh
@@ -3,7 +3,7 @@
 export LC_ALL=en_US.UTF-8
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 main()
 {
@@ -22,12 +22,12 @@ main()
   fi
 
   FORMAT=$(get_tmux_option "@dracula-spotify-tui-format" "%f %s %t - %a")
-  spotify_playback=$(spt playback -f "${FORMAT}")
+  spotify_playback=$(spt playback -f "$FORMAT")
   max_len=$(get_tmux_option "@dracula-spotify-tui-max-len" 0)
   if [[ $max_len -ne 0 ]] ; then
-    echo ${spotify_playback} | head -c $max_len
+    echo "$spotify_playback" | head -c "$max_len"
   else
-    echo ${spotify_playback}
+    echo "$spotify_playback"
   fi
 }
 

--- a/scripts/synchronize_panes.sh
+++ b/scripts/synchronize_panes.sh
@@ -5,11 +5,11 @@ export LC_ALL=en_US.UTF-8
 label=$1
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 get_synchronize_panes_status() {
   current_synchronize_panes_status=$(get_tmux_window_option "synchronize-panes" "off")
-  echo $current_synchronize_panes_status
+  echo "$current_synchronize_panes_status"
 }
 
 main()
@@ -19,7 +19,7 @@ main()
   synchronize_panes_label=$label
   synchronize_panes_status=$(get_synchronize_panes_status)
   echo "$synchronize_panes_label $synchronize_panes_status"
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run main driver

--- a/scripts/sys_temp.sh
+++ b/scripts/sys_temp.sh
@@ -15,7 +15,7 @@ main() {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   echo "$(get_temp)"
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run main driver

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -5,16 +5,16 @@ export LC_ALL=en_US.UTF-8
 label=$1
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $current_dir/utils.sh
+source "$current_dir"/utils.sh
 
 main() {
   # storing the refresh rate in the variable RATE, default is 5
   RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
   OUTPUT_STRING="N/A" 
   terraform_dir="$(tmux display-message -p '#{pane_current_path}')/.terraform"
-  if [ -d $terraform_dir ]; then
+  if [ -d "$terraform_dir" ]; then
     current_workspace=$(terraform workspace show 2>/dev/null)
-    OUTPUT_STRING="${current_workspace}"
+    OUTPUT_STRING="$current_workspace"
   fi
   if [ "$label" = "" ]
   then
@@ -23,7 +23,7 @@ main() {
       echo "⚙️ ${label} ${OUTPUT_STRING}"
   fi
 
-  sleep $RATE
+  sleep "$RATE"
 }
 
 # run the main driver

--- a/scripts/tmux_ram_info.sh
+++ b/scripts/tmux_ram_info.sh
@@ -11,7 +11,7 @@ get_cpids_linux() {
   local cpid
   echo "$ppid"
   cpids="$(pgrep -P "$ppid")"
-  for cpid in $cpids; do
+  for cpid in "${cpids[@]}"; do
     get_cpids_linux "$cpid"
   done
 }
@@ -22,7 +22,7 @@ get_cpids_unix() {
   local cpid
   echo "$ppid"
   cpids="$(pgrep -aP "$ppid")"
-  for cpid in $cpids; do
+  for cpid in "${cpids[@]}"; do
     get_cpids_unix "$cpid"
   done
 }
@@ -53,7 +53,7 @@ round() {
     num="$1"
     scale="$2"
   fi
-  printf "%.${scale}f" "${num}"
+  printf "%.${scale}f" "$num"
 }
 
 get_tmux_ram_usage()

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -4,7 +4,7 @@ get_tmux_option() {
   local option="$1"
   local default_value="$2"
   local option_value="$(tmux show-option -gqv "$option")"
-  if [ -z "$option_value" ]; then
+  if [ "$option_value" = "" ]; then
     echo "$default_value"
   else
     echo "$option_value"
@@ -15,7 +15,7 @@ get_tmux_window_option() {
   local option="$1"
   local default_value="$2"
   local option_value="$(tmux show-window-options -v "$option")"
-  if [ -z "$option_value" ]; then
+  if [ "$option_value" = "" ]; then
     echo "$default_value"
   else
     echo "$option_value"
@@ -27,10 +27,10 @@ normalize_percent_len() {
   # the max length that the percent can reach, which happens for a two digit number with a decimal house: "99.9%"
   max_len=5
   percent_len=${#1}
-  let diff_len=$max_len-$percent_len
+  let diff_len="$max_len-$percent_len"
   # if the diff_len is even, left will have 1 more space than right
-  let left_spaces=($diff_len+1)/2
-  let right_spaces=($diff_len)/2
-  printf "%${left_spaces}s%s%${right_spaces}s\n" "" $1 ""
+  let left_spaces=("$diff_len"+1)/2
+  let right_spaces=("$diff_len")/2
+  printf "%${left_spaces}s%s%${right_spaces}s\n" "" "$1" ""
 }
 

--- a/scripts/weather_wrapper.sh
+++ b/scripts/weather_wrapper.sh
@@ -26,11 +26,11 @@ function main() {
 
   if (((_now - _last) > INTERVAL)); then
     # Run weather script here
-    "${_current_dir}/weather.sh" "$_show_fahrenheit" "$_show_location" "$_location" >"${DATAFILE}"
-    printf '%s' "$_now" >"${LAST_EXEC_FILE}"
+    "${_current_dir}/weather.sh" "$_show_fahrenheit" "$_show_location" "$_location" >"$DATAFILE"
+    printf '%s' "$_now" >"$LAST_EXEC_FILE"
   fi
 
-  cat "${DATAFILE}"
+  cat "$DATAFILE"
 }
 
 main "$@"


### PR DESCRIPTION
Running shellharden on bash files makes them more secure and less buggy as vulnerabilities to malicious glob expansion and the like are reduced.

GHA CI check for PRs incoming... eventually...