### PR TITLE
fix(nextwork): airport response is multi-line if wifi disabled

### DIFF
--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -25,7 +25,7 @@ get_ssid()
 
     Darwin)
       local wifi_network=$(ipconfig getsummary en0 | awk -F ' SSID : '  '/ SSID : / {print $2}')
-      local airport=$(networksetup -getairportnetwork en0 | cut -d ':' -f 2)
+      local airport=$(networksetup -getairportnetwork en0 | cut -d ':' -f 2 | head -n 1)
 
       if [[ $airport != "You are not associated with an AirPort network." ]]; then
         echo "$wifi_label$airport" | sed 's/^[[:blank:]]*//g'


### PR DESCRIPTION
If WiFi is fully disabled (toggled off on macOS), the response from the `networksetup` call, while determining if you're on an airport network, fails to be correctly compared due to an additional line of text added.

```bash
› networksetup -getairportnetwork en0 | cut -d ':' -f 2
You are not associated with an AirPort network.
Wi-Fi power is currently off.
```

This results in the network widget displaying the long string "Wi-Fi power is currently off."

This change simply sets it to always grab the first line instead.

```bash
› networksetup -getairportnetwork en0 | cut -d ':' -f 2 | head -n 1
You are not associated with an AirPort network.
```

Which resulted in the correct display of showing my laptop was on Ethernet.