### PR TITLE
gha: ubuntu-20.04 -> ubuntu-latest

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout
       uses: actions/checkout@master


### PR DESCRIPTION
ubuntu-20.04 was deprecated and removed from use on 20250415. Updating to latest prevents us from having this issue in the future. As this is a pretty low-consequence test, I feel comfortable using the latest version here.