### PR TITLE
Feature/compact alt

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9,6 +9,7 @@
 - [Plugins](#Plugins)
   - [attached-clients](#attached-clients---up)
   - [battery](#battery---up)
+  - [compact-alt](#compact-alt---up)
   - [continuum](#continuum---up)
   - [cpu-usage](#cpu-usage---up)
   - [cwd](#cwd---up)
@@ -196,6 +197,44 @@ alternatively, if you have no battery and would like a nerdfont icon to indicate
 
 ```bash
 set -g @dracula-no-battery-label " "
+```
+
+### compact-alt - [up](#table-of-contents)
+This widget allows the user to switch to an alternate list of widgets when the terminal becomes narrow.
+Switching only works if the widget is added to `set -g @dracula-plugins "your-plugins-here"`.
+
+to set what widgets should be shown in narrow mode, set the following variable. *make sure to include the compact-alt widget as you won't be able to switch out of narrow mode otherwise.*
+
+```bash
+set -g @dracula-narrow-plugins "compact-alt battery network weather"
+```
+
+to determine when to switch to narrow mode, set the following variable.
+any value below this threshold is considered narrow.
+
+```bash
+set -g @dracula-compact-min-width 140
+```
+
+the compact-alt widget needs to reload your tmux config to switch from wide to narrow and back.
+therefore, you need to make sure to set the right path to your config file.
+
+```bash
+set -g @dracula-config-path "$HOME/.config/tmux/tmux.conf"
+```
+
+if you want to see your window with and whether narrow mode is active, set the following, which is false per default.
+
+```bash
+set -g @dracula-compact-alt-verbose true
+```
+
+this widget maintains a global variable informing about whether narrow mode is active.
+that variable should never be touched by the user and could potentially be used by other widgets/ plugins.
+
+```bash
+# NEVER DO:
+set -g @dracula-narrow-mode some-value
 ```
 
 ### continuum - [up](#table-of-contents)

--- a/scripts/compact_alt.sh
+++ b/scripts/compact_alt.sh
@@ -8,7 +8,7 @@ source $current_dir/utils.sh
 main()
 {
   # get options
-  min_width=$(get_tmux_option "@dracula-compact-min-width" "200")
+  min_width=$(get_tmux_option "@dracula-compact-min-width" "140")
 
   # get current window with
   local window_width
@@ -27,10 +27,14 @@ main()
   # if width changed, set global var and reload
   if [[ "$narrow" != "$narrow_mode" ]]; then
     tmux set -g @dracula-narrow-mode $narrow
-    tmux source-file $(get_tmux_option "@dracula-config-path" "$HOME/.config/tmux/tmux.conf")
+    tmux source-file "$(get_tmux_option "@dracula-config-path" "$HOME/.config/tmux/tmux.conf")"
   fi
-  # TODO: test and think about what to display
-  echo "$window_width aa $narrow"
+
+  # show widget info if verbose
+  verbose=$(get_tmux_option "@dracula-compact-alt-verbose" false)
+  if $verbose; then
+    echo "$window_width - $narrow"
+  fi
 }
 
 #run main driver program

--- a/scripts/compact_alt.sh
+++ b/scripts/compact_alt.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# setting the locale, some users have issues with different locales, this forces the correct one
+export LC_ALL=en_US.UTF-8
+
+current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+
+main()
+{
+  # get options
+  min_width=$(get_tmux_option "@dracula-compact-min-width" "200")
+
+  # get current window with
+  local window_width
+  window_width=$(tmux display-message -p "#{window_width}")
+
+  # determine whether narrow
+  if [[ "$window_width" -lt "$min_width" ]]; then
+    narrow=true
+  else
+    narrow=false
+  fi
+
+  # get whether narrow previously
+  narrow_mode="$(tmux show-option -gqv '@dracula-narrow-mode')"
+
+  # if width changed, set global var and reload
+  if [[ "$narrow" != "$narrow_mode" ]]; then
+    tmux set -g @dracula-narrow-mode $narrow
+    tmux source-file ~/.config/tmux/tmux.conf
+  fi
+  echo "$window_width aa $narrow"
+}
+
+#run main driver program
+main

--- a/scripts/compact_alt.sh
+++ b/scripts/compact_alt.sh
@@ -27,8 +27,9 @@ main()
   # if width changed, set global var and reload
   if [[ "$narrow" != "$narrow_mode" ]]; then
     tmux set -g @dracula-narrow-mode $narrow
-    tmux source-file ~/.config/tmux/tmux.conf
+    tmux source-file $(get_tmux_option "@dracula-config-path" "$HOME/.config/tmux/tmux.conf")
   fi
+  # TODO: test and think about what to display
   echo "$window_width aa $narrow"
 }
 

--- a/scripts/compact_alt.sh
+++ b/scripts/compact_alt.sh
@@ -35,6 +35,9 @@ main()
   if $verbose; then
     echo "$window_width - $narrow"
   fi
+  # storing the refresh rate in the variable RATE, default is 5
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+  sleep $RATE
 }
 
 #run main driver program

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -37,8 +37,14 @@ main() {
   time_format=$(get_tmux_option "@dracula-time-format" "")
   show_ssh_session_port=$(get_tmux_option "@dracula-show-ssh-session-port" false)
   show_libreview=$(get_tmux_option "@dracula-show-libreview" false)
-  IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
   show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
+
+  narrow_mode=$(get_tmux_option "@dracula-narrow-mode" false)
+  if $narrow_mode; then
+    IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-narrow-plugins" "compact-alt battery network weather")
+  else
+    IFS=' ' read -r -a plugins <<< $(get_tmux_option "@dracula-plugins" "battery network weather")
+  fi
 
   # Dracula Color Pallette
   white="#f8f8f2"
@@ -187,6 +193,11 @@ main() {
         colors[1]="dark_gray"
         script="${script} not found!"
       fi
+
+    elif [ $plugin = "compact-alt" ]; then
+      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-compact-alt-colors" "dark_gray white")
+      tmux set-option -g status-right-length 250
+      script="#($current_dir/compact_alt.sh)"
 
     elif [ $plugin = "cwd" ]; then
       IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-cwd-colors" "dark_gray white")


### PR DESCRIPTION
Using tmux full screen is awesome, but if you got a lot of widgets and then narrow the terminal it's cut off and ugly real quick.   
This PR adds a widget that checks the tmux windows width and switches the list of active widgets to an alternate one so that the narrow space is filled by only the most important widgets.

This also adds the ability to use the @dracula-narrow-mode variable in other widgets to dynamically adjust the amount of content displayed.

from the docs:
This widget allows the user to switch to an alternate list of widgets when the terminal becomes narrow.
Switching only works if the widget is added to `set -g @dracula-plugins "your-plugins-here"`.

to set what widgets should be shown in narrow mode, set the following variable. *make sure to include the compact-alt widget as you won't be able to switch out of narrow mode otherwise.*

```bash
set -g @dracula-narrow-plugins "compact-alt battery network weather"
```

to determine when to switch to narrow mode, set the following variable.
any value below this threshold is considered narrow.

```bash
set -g @dracula-compact-min-width 140
```

the compact-alt widget needs to reload your tmux config to switch from wide to narrow and back.
therefore, you need to make sure to set the right path to your config file.

```bash
set -g @dracula-config-path "$HOME/.config/tmux/tmux.conf"
```

if you want to see your window with and whether narrow mode is active, set the following, which is false per default.

```bash
set -g @dracula-compact-alt-verbose true
```

this widget maintains a global variable informing about whether narrow mode is active.
that variable should never be touched by the user and could potentially be used by other widgets/ plugins.

```bash
# NEVER DO:
set -g @dracula-narrow-mode some-value
```
