### PR TITLE
Fix cpu_info bug

### DIFF
--- a/scripts/cpu_info.sh
+++ b/scripts/cpu_info.sh
@@ -9,7 +9,7 @@ get_percent()
 {
   case $(uname -s) in
     Linux)
-      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+      percent=$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "[C]pu(s)" | tail -1 | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
       normalize_percent_len $percent
       ;;
 


### PR DESCRIPTION
Grepping the output of top for `Cpu(s)` includes a row for the `grep "Cpu(s)"` process, which sometimes ends up being selected by `tail -1`, causing a nonsensical %CPU reading (in orange in the screenshot below).

<img width="437" alt="Screenshot 2025-05-16 at 2 22 58 AM" src="https://github.com/user-attachments/assets/c73fd4f6-e123-4f16-b9ab-c8c94bb44adb" />

This fix uses the pattern `[C]pu(s)` to exclude the search pattern in the grep process itself, a la this stackexchange https://unix.stackexchange.com/a/74186.
<img width="441" alt="Screenshot 2025-05-16 at 2 24 47 AM" src="https://github.com/user-attachments/assets/10f735ad-34b6-442d-85a0-d21cbceeea88" />

It is still possible for the grep pattern to match `Cpu(s)` in the arguments for another process, but that seems much less likely.