### PR TITLE
Mac player

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,7 +22,7 @@
   - [Kerberos TGT (krbtgt)](#Kerberos-TGT---up)
   - [kubernetes-context](#kubernetes-context---up)
   - [libreview](#libreview---up)
-  - [mac-player](#libreview---up)
+  - [mac-player](#mac-player---up)
   - [mpc](#mpc---up)
   - [network](#network---up)
   - [network-bandwidth](#network-bandwidth---up)
@@ -529,6 +529,12 @@ To change player icons:
 set -g @dracula-mac-player-play-icon "♪ "
 set -g @dracula-mac-player-pause-icon "❚❚ "
 
+```
+
+To change length of the widget (length 25 by default):
+
+```bash
+set -g @dracula-mac-player-length 25
 ```
 
 To activate the remote:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -558,7 +558,7 @@ The default keybinds are:
 To change the keybinds:
 
 ```bash
-set -g @dracula-mac-player-remote-pp "P"
+set -g @dracula-mac-player-remote-play-pause "P"
 set -g @dracula-mac-player-remote-back "R"
 set -g @dracula-mac-player-remote-next "N"
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -511,7 +511,7 @@ The current supported apps are:
 - Native Players:
   - Spotify
   - Music - Apple Music
-- Browser Players ( Active Tab should consists of this players ):
+- Browser Players (active tab must match one of these URLs and requires Google Chrome or Safari):
   - youtube.com/watch
   - open.spotify.com
 
@@ -546,7 +546,7 @@ set -g @dracula-mac-player-remote true
 To specify the app to use(`"Music"` or `"Spotify"`):
 
 ```bash
-set -g @dracule-mac-player-app "Music"
+set -g @dracula-mac-player-app "Music"
 ```
 
 The default keybinds are:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -526,8 +526,8 @@ NOTE: `set -g @dracula-refresh-rate 5` affects this widget
 To change player icons:
 
 ```bash
-set -g @dracula-mac-player-play-icon" "♪ "
-set -g @dracula-mac-player-pause-icon" "❚❚ "
+set -g @dracula-mac-player-play-icon "♪ "
+set -g @dracula-mac-player-pause-icon "❚❚ "
 
 ```
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -502,20 +502,20 @@ set -g @dracula-kubernetes-eks-extract-account true
 This script retrieves and displays continuous glucose monitoring (CGM) data from the LibreView API.
 It caches the data to minimize API requests and displays the latest glucose level along with a trend indicator in a Tmux status bar.
 
-### mac-player - [up](CONFIG#table-of-contents)
+### mac-player - [up](#table-of-contents)
 
 This widget and script displays music information provided by the native macOS players.
-It also a remote-player feature.
 
 The current supported apps are:
 
-- Native Players
+- Native Players:
   - Spotify
   - Music - Apple Music
-- Browser Players ( don't have player state option )
+- Browser Players ( Active Tab should consists of this players ):
   - youtube.com/watch
   - open.spotify.com
 
+It also has a remote-player feature.
 The supported remote players are:
 
 - Spotify

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,6 +1,7 @@
 # [tmux](https://github.com/tmux/tmux/wiki)
 
 ## Table of Contents
+
 - [Configuration](#Configuration---up)
 - [Status bar options](#status-bar-options---up)
   - [Powerline](#powerline---up)
@@ -21,6 +22,7 @@
   - [Kerberos TGT (krbtgt)](#Kerberos-TGT---up)
   - [kubernetes-context](#kubernetes-context---up)
   - [libreview](#libreview---up)
+  - [mac-player](#libreview---up)
   - [mpc](#mpc---up)
   - [network](#network---up)
   - [network-bandwidth](#network-bandwidth---up)
@@ -87,6 +89,7 @@ set -g @dracula-show-empty-plugins false
 ```
 
 ### Powerline - [up](#table-of-contents)
+
 Enable powerline symbols
 
 ```bash
@@ -94,6 +97,7 @@ set -g @dracula-show-powerline true
 ```
 
 Enable edge icons
+
 ```bash
 set -g @dracula-show-edge-icons true
 ```
@@ -118,6 +122,7 @@ set -g @dracula-inverse-divider 
 ```
 
 ### Left Icon - [up](#table-of-contents)
+
 - The left icon can be set to anything static you'd like.
 - However if you use tmux on multiple machines, it may be helpful to display the hostname.
 - If you use multiple sessions simultaneously it can be good to name them and have the name in the left icon.
@@ -143,6 +148,7 @@ more formats can be found here, though those without a shorthand like #H need to
 besides formats, any other string can be used.
 
 additionally the left icons padding can be set like so:
+
 ```bash
 # default is 1, it can accept any number and 0 disables padding.
 set -g @dracula-left-icon-padding 1
@@ -157,7 +163,9 @@ This allows for the use of custom themes like catppuccin or gruvbox.
 For everything regarding colors, please refer to [the color theming directory](/docs/color_theming/README.md).
 
 ## Plugins
+
 ### attached-clients - [up](#table-of-contents)
+
 This widget provides the number of clients attached to the current tmux session.
 
 Set the minimum number of clients to show (otherwise, show nothing)
@@ -174,9 +182,11 @@ set -g @dracula-clients-plural clients
 ```
 
 ### battery - [up](#table-of-contents)
+
 This widget provides information about the current charge of the battery, whether it is attached to a powersupply and charging from it, or running off the powersupply without charging. it also detects desktop pcs having no battery.
 
 Display any icon for the battery you'd like with:
+
 ```bash
 set -g @dracula-battery-label "♥ "
 ```
@@ -202,10 +212,11 @@ set -g @dracula-no-battery-label " "
 ```
 
 ### compact-alt - [up](#table-of-contents)
+
 This widget allows the user to switch to an alternate list of widgets when the terminal becomes narrow.
 Switching only works if the widget is added to `set -g @dracula-plugins "your-plugins-here"`.
 
-to set what widgets should be shown in narrow mode, set the following variable. *make sure to include the compact-alt widget as you won't be able to switch out of narrow mode otherwise.*
+to set what widgets should be shown in narrow mode, set the following variable. _make sure to include the compact-alt widget as you won't be able to switch out of narrow mode otherwise._
 
 ```bash
 set -g @dracula-narrow-plugins "compact-alt battery network weather"
@@ -242,6 +253,7 @@ set -g @dracula-narrow-mode some-value
 ### continuum - [up](#table-of-contents)
 
 Set the output mode. Options are:
+
 - **countdown**: Show a T- countdown to the next save (default)
 - **time**: Show the time since the last save
 - **alert**: Hide output if no save has been performed recently
@@ -258,6 +270,7 @@ set -g @dracula-continuum-time-threshold 60
 ```
 
 Other options.
+
 ```bash
 @dracula-continuum-first-save
 @resurrect-dir
@@ -266,110 +279,136 @@ Other options.
 ```
 
 ### cpu-arch - [up](#table-of-contents)
+
 This widget displays the cpu architecture.
 
 possible nerdfont settings for cpu arch label:
+
 ```bash
 set -g @dracula-cpu-arch-label "󰍛 "
 ```
 
 ### cpu-usage - [up](#table-of-contents)
+
 This widget displays the cpu usage in percent by default, but can display cpu load on linux.
 Load average – is the average system load calculated over a given period of time of 1, 5 and 15 minutes (output: x.x x.x x.x)
+
 ```bash
 set -g @dracula-cpu-display-load true
 ```
 
 possible nerdfont settings for cpu usage label:
+
 ```bash
 set -g @dracula-cpu-usage-label " "
 ```
 
 nerdfont icons to consider:
+
 ```bash
    󰍛 󰘚 󰻟 󰻠
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### cwd - [up](#table-of-contents)
+
 This widget displays the path of the current working directory, where the path of the users home directory will be shortened to `~`.
 
 The maximum number of directories and number of characters used for that is unlimited by default, but can be set with the following two options:
+
 ```bash
 set -g @dracula-cwd-max-dirs "0"
 set -g @dracula-cwd-max-chars "0"
 ```
+
 ### fossil - [up](#table-of-contents)
+
 **TODO**
+
 ### git - [up](#table-of-contents)
+
 This widget displays info about the current git repository.
 
 Hide details of git changes
+
 ```bash
 set -g @dracula-git-disable-status true
 ```
 
 Set symbol to use for when branch is up to date with HEAD
+
 ```bash
 # default is ✓. Avoid using non unicode characters that bash uses like $, * and !
 set -g @dracula-git-show-current-symbol ✓
 ```
 
 Set symbol to use for when branch diverges from HEAD
+
 ```bash
 # default is unicode !. Avoid bash special characters
 set -g @dracula-git-show-diff-symbol !
 ```
 
 Set symbol or message to use when the current pane has no git repo
+
 ```bash
 # default is unicode no message
 set -g @dracula-git-no-repo-message ""
 ```
 
 Hide untracked files from being displayed as local changes
+
 ```bash
 # default is false
 set -g @dracula-git-no-untracked-files true
 ```
 
 Show remote tracking branch together with diverge/sync state
+
 ```bash
 # default is false
 set -g @dracula-git-show-remote-status true
 ```
 
 ### gpu-info - [up](#table-of-contents)
+
 These widgets display the current computational, ram, and power usage of installed graphics cards.
 They are split into widgets with the names: `gpu-usage, gpu-ram-usage, gpu-power-draw`.
 
 hardware support:
+
 - full support for NVIDIA gpus on linux, when using official nvidia drivers.
 - partial support for apple m-chips on MacOS.
 - partial support for amd and intel on linux
 
 If your gpu is not recognised, force the script to assume a certain brand.
+
 ```bash
 set -g @dracula-force-gpu "NVIDIA"
 ```
 
 To display the used vram in percent (gigabyte is default unit):
+
 ```bash
 set -g @dracula-gpu-vram-percent true
 ```
 
 Vram usage is displayed in gigabyte without decimal places per default. To change that behaviour, use the following options with the respective number of decimal places you'd like to get:
+
 ```bash
 set -g @dracula-gpu-vram-used-accuracy ".2f"
 set -g @dracula-gpu-vram-total-accuracy ".1f"
 ```
 
 To display the power usage in percent (watt is default unit):
+
 ```bash
 set -g @dracula-gpu-power-percent true
 ```
 
 Possible nerdfont settings for gpu info labels:
+
 ```bash
 set -g @dracula-gpu-power-label "󰢮 "
 set -g @dracula-gpu-usage-label "󰢮 "
@@ -377,44 +416,53 @@ set -g @dracula-gpu-vram-label "󰢮 "
 ```
 
 nerdfont icons to consider:
+
 ```bash
 󰢮
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### hg - [up](#table-of-contents)
+
 This widget displays info about the current mercurial repository.
 
 Hide details of hg changes
+
 ```bash
 set -g @dracula-hg-disable-status true
 ```
 
 Set symbol to use for when branch is up to date with HEAD
+
 ```bash
 #default is ✓.Avoid using non unicode characters that bash uses like $, * and !
 set -g @dracula-hg-show-current-symbol ✓
 ```
 
 Set symbol to use for when branch diverges from HEAD
+
 ```bash
 #default is unicode !.Avoid bash special characters
 set -g @dracula-hg-show-diff-symbol !
 ```
 
 Set symbol or message to use when the current pane has no hg repo
+
 ```bash
 #default is unicode no message
 set -g @dracula-hg-no-repo-message ""
 ```
 
 Hide untracked files from being displayed as local changes
+
 ```bash
 #default is false
 set -g @dracula-hg-no-untracked-files false
 ```
 
 ### Kerberos TGT - [up](#table-of-contents)
+
 This widgets name is `krbtgt`.
 
 Set the principal to check the TGT expiration date for (with or without the REALM)
@@ -450,28 +498,91 @@ set -g @dracula-kubernetes-eks-extract-account true
 ```
 
 ### libreview - [up](#table-of-contents)
+
 This script retrieves and displays continuous glucose monitoring (CGM) data from the LibreView API.
 It caches the data to minimize API requests and displays the latest glucose level along with a trend indicator in a Tmux status bar.
+
+### mac-player - [up](CONFIG#table-of-contents)
+
+This widget and script displays music information provided by the native macOS players.
+It also a remote-player feature.
+
+The current supported apps are:
+
+- Native Players
+  - Spotify
+  - Music - Apple Music
+- Browser Players ( don't have player state option )
+  - youtube.com/watch
+  - open.spotify.com
+
+The supported remote players are:
+
+- Spotify
+- Music - Apple Music
+
+NOTE: `set -g @dracula-refresh-rate 5` affects this widget
+
+To change player icons:
+
+```bash
+set -g @dracula-mac-player-play-icon" "♪ "
+set -g @dracula-mac-player-pause-icon" "❚❚ "
+
+```
+
+To activate the remote:
+
+```bash
+set -g @dracula-mac-player-remote true
+```
+
+To specify the app to use(`"Music"` or `"Spotify"`):
+
+```bash
+set -g @dracule-mac-player-app "Music"
+```
+
+The default keybinds are:
+
+- `<prefix> + P` - Play/Pause
+- `<prefix> + R` - Back to position 0/previous track
+- `<prefix> + N` - Next track
+
+To change the keybinds:
+
+```bash
+set -g @dracula-mac-player-remote-pp "P"
+set -g @dracula-mac-player-remote-back "R"
+set -g @dracula-mac-player-remote-next "N"
+```
+
 ### mpc - [up](#table-of-contents)
+
 This widget displays music information provided by mpc.
 
 To format the display format:
+
 ```bash
 set -g @dracula-mpc-format "%title% - %artist%"
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### network - [up](#table-of-contents)
+
 This widget displays one of three states: offline, ethernet connected, or wifi connected.
 however, per default **this will only display the wifi you're connected to, if it provides internet access!**
 
 You can use different hosts to ping in order to check for a wifi or wired connection.
 If you frequently use networks without internet access, you can use local ip-addresses here to still display the connection.
+
 ```bash
 set -g @dracula-network-hosts "1.1.1.1 8.8.8.8"
 ```
 
 Possible nerdfont settings for network info:
+
 ```bash
 set -g @dracula-network-ethernet-label "󰈀 Eth"
 set -g @dracula-network-offline-label "󱍢 "
@@ -479,6 +590,7 @@ set -g @dracula-network-wifi-label " "
 ```
 
 Nerdfont icons to consider:
+
 ```
 ethernet: 󰈀 󰒪 󰒍 󰌗 󰌘
 offline: 󰖪  󱍢
@@ -486,25 +598,34 @@ wifi:      󰖩  󰘊 󰒢
 ```
 
 Known issues:
+
 - If for some reason `iw` is only in the path for root and not the normal user, wifi connections will be considered ethernet connections.
+
 ### network-bandwidth - [up](#table-of-contents)
+
 This widget gives the currently used up and download speeds per second for one interface.
 
 The most common interfaces name are `eth0` for a wired connection and `wlan0` for a wireless connection.
 To set a specific network interface you'd like to monitor, used:
+
 ```bash
 set -g @dracula-network-bandwidth "eno0"
 ```
+
 To display the interface name alongside the speeds, set:
+
 ```bash
 set -g @dracula-network-bandwidth-show-interface true
 ```
+
 Per default, this widget checks the speeds as frequently as it can. to set longer intervals, use the following:
+
 ```bash
 set -g @dracula-network-bandwidth-interval 5
 ```
 
 ### network-ping - [up](#table-of-contents)
+
 This widget displays the current ping to a specific server.
 
 You can configure which server (hostname, IP) you want to ping and at which rate (in seconds). Default is google.com at every 5 seconds.
@@ -515,77 +636,100 @@ set -g @dracula-ping-rate 5
 ```
 
 ### network-vpn - [up](#table-of-contents)
+
 This widget displays whether a vpn is connected.
 
 These options are not available yet.
+
 ```bash
 set -g @dracula-network-vpn-verbose true
 set -g @dracula-network-vpn-label
 ```
+
 ### playerctl - [up](#table-of-contents)
+
 This widget displays playerctl info.
 
 Set the playerctl metadata format like so:
+
 ```bash
 set -g @dracula-playerctl-format "►  {{ artist }} - {{ title }}"
 ```
 
 ### ram-usage - [up](#table-of-contents)
+
 This widget displays the currently used ram as GB per GB.
 
 Possible nerdfont settings for ram usage:
+
 ```bash
 set -g @dracula-ram-usage-label " "
 ```
 
 Nerdfont icons to consider:
+
 ```
    󰍛 󰘚
 ```
+
 ### spotify-tui - [up](#table-of-contents)
+
 This widget displays music information provided by spotify-tui. Spotify-tui must be installed to use this widget.
 
 To format the display format:
+
 ```bash
 set -g @dracula-spotify-tui-format "%f %s %t - %a"
 ```
 
 To limit the maximum length (0 means unlimited length):
+
 ```bash
 set -g @dracula-spotify-tui-max-len 30
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### ssh-session - [up](#table-of-contents)
+
 This widget displays the current username@host combination, both of the local machine as well as when connected via ssh.
 
 To output nothing (and maybe hide the widget) when not connected via ssh:
+
 ```bash
 set -g @dracula-show-ssh-only-when-connected true
 ```
 
 Show SSH session port:
+
 ```bash
 set -g @dracula-show-ssh-session-port true
 ```
 
 nerdfont icons to consider:
+
 ```
 󰣀
 ```
+
 ### synchronize-panes - [up](#table-of-contents)
+
 This widget displays whether the tmux panes are currently synchronised or not.
 
 To change the label:
+
 ```bash
 set -g @dracula-synchronize-panes-label "Sync"
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### sys-temp - [up](#table-of-contents)
+
 This widget displays the system temperature.
 
 ### terraform - [up](#table-of-contents)
+
 **TODO**
 
 ```
@@ -593,7 +737,9 @@ set -g @dracula-terraform-label ""
 ```
 
 `set -g @dracula-refresh-rate 5` affects this widget
+
 ### time - [up](#table-of-contents)
+
 This widget displays current date and time.
 
 Disable timezone
@@ -615,33 +761,41 @@ set -g @dracula-military-time true
 ```
 
 Set custom time format e.g (2023-01-01 14:00)
+
 ```bash
 set -g @dracula-time-format "%F %R"
 ```
+
 See [[this page]](https://man7.org/linux/man-pages/man1/date.1.html) for other format symbols.
 
 ### tmux-ram-usage - [up](#table-of-contents)
+
 This widget displays the ram currently used by tmux.
 
 Possible nerdfont settings for tmux ram usage:
+
 ```
 @dracula-tmux-ram-usage-label " "
 ```
 
 Nerdfont icons to consider:
+
 ```
    󰍛 󰘚
 ```
 
 ### uptime - [up](#table-of-contents)
+
 Shows how long the system has been running.
 
 Possible nerdfont settings for uptime:
+
 ```
 @dracula-uptime-label "󱎫 "
 ```
 
 ### weather - [up](#table-of-contents)
+
 Show weather information for given location.
 
 Switch from default fahrenheit to celsius
@@ -663,5 +817,6 @@ set -g @dracula-show-location false
 ```
 
 ### custom:script-name - [up](#table-of-contents)
+
 For testing/ running custom plugins, put the bash script into the scripts directory of dracula/tmux plugin.
 Additionally, in the `@dracula-plugins` option, add the script as `custom:name-of-script.sh`.

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -56,6 +56,7 @@ main() {
   green="#50fa7b"
   orange="#ffb86c"
   red="#ff5555"
+  purple="#b166cc"
   pink="#ff79c6"
   yellow="#f1fa8c"
 
@@ -267,6 +268,11 @@ main() {
     elif [ $plugin = "attached-clients" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-attached-clients-colors" "cyan dark_gray")
       script="#($current_dir/attached_clients.sh)"
+
+
+     elif [ $plugin = "mac-player" ]; then
+      IFS=' ' read -r -a colors  <<< $(get_tmux_option "@dracula-mac-player-colors" "purple dark_gray")
+      script="#($current_dir/mac-player.sh)"
 
     elif [ $plugin = "mpc" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-mpc-colors" "green dark_gray")

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -202,7 +202,7 @@ main() {
   REMOTE_APP=$(get_tmux_option "@dracula-mac-player-app" "Spotify")
 
   # Remote Control Buttons Customizations
-  PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-pp" "P")
+  PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-play-pause" "P")
   BACK_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-back" "R")
   NEXT_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-next" "N")
 

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -195,7 +195,7 @@ main() {
 
   # Active Player variables
   PLAY_ICON=$(get_tmux_option "@dracula-mac-player-play-icon" "♪")
-  PAUSE_ICON=$(get_tmux_option "@dracula-mac-player-pause" "❚❚ ")
+  PAUSE_ICON=$(get_tmux_option "@dracula-mac-player-pause-icon" "❚❚ ")
   MAX_LENGTH=$(get_tmux_option "@dracula-mac-player-length" 25)
 
   # Remote variables

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -212,7 +212,7 @@ main() {
   # os checker
   if [[ "$OSTYPE" != "darwin"* ]]; then
     echo ""
-    exit 0
+    exit 1
   fi
 
   # Remote Access

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+export LC_ALL=en_US.UTF-8
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$current_dir/utils.sh"
+
+
+function trackStatus() {
+	local active_player
+  local pause_icon="$1"
+  local play_icon="$2"
+
+	active_player=$(osascript -e "
+	property playerList : {\"Spotify\", \"Music\", \"Safari\", \"Google Chrome\"}
+	property nativePlayerList : {\"Spotify\", \"Music\"}
+
+
+  -- Detect the Player being used
+	on detectPlayer()
+		repeat with appName in playerList
+			set currentApp to contents of appName
+      -- process checker
+      -- native and browser checker
+			if (running of application currentApp) then
+				if (currentApp is not in nativePlayerList) then
+					return browserPlayer(currentApp)
+				else
+					return nativePlayer(currentApp)
+				end if
+			else
+			end if
+		end repeat
+
+		return \"No App Supported\"
+	end detectPlayer
+
+
+  -- nativePlayer Function: supports spotify and apple-music
+	on nativePlayer(nativeName)
+		if not (running of application nativeName) then return \"not running\"
+		if nativeName is \"Spotify\" then
+			tell application \"Spotify\"
+				if player state is stopped then return \"stopped\"
+				set trackArtist to artist of current track
+				set trackName to name of current track
+				if player state is paused then
+					return \"$pause_icon \" & trackArtist & \" - \" & trackName
+				else
+			return \"$play_icon \" & trackArtist & \" - \" & trackName
+				end if
+
+			end tell
+		else if nativeName is \"Music\" then
+			tell application \"Music\"
+				if player state is stopped then return \"stopped\"
+				set trackArtist to artist of current track
+				set trackName to name of current track
+				if player state is paused then
+					return \"$pause_icon \" & trackArtist & \" - \" & trackName
+				else
+			return \"$play_icon \" & trackArtist & \" - \" & trackName
+				end if
+
+			end tell
+		end if
+
+	end nativePlayer
+
+  -- browserPlayer Function: supports Safari and Google Chrome
+	on browserPlayer(browserName)
+		if (running of application \"Safari\") and (browserName is \"Safari\") then
+			tell application \"Safari\"
+				set currentTab to the front document
+				set currentURL to URL of currentTab
+				set pageTitle to name of currentTab
+			end tell
+		else if (running of application \"Google Chrome\") and (browserName is \"Google Chrome\") then
+			tell application \"Google Chrome\"
+				set currentTab to active tab of front window
+				--- set currentTab to active tab of front window
+				set currentURL to URL of currentTab
+				set pageTitle to title of currentTab
+			end tell
+		else
+			return \"Not supported\"
+		end if
+
+
+		-- Check if it's a YouTube video page
+		if currentURL contains \"youtube.com/watch\" then
+			-- YouTube video titles usually follow this format: \"Artist - Track Name\"
+			set AppleScript's text item delimiters to \" - \"
+			set titleParts to text items of pageTitle
+
+			if (count of titleParts) ≥ 2 then
+				set artistName to item 1 of titleParts
+				set trackName to item 2 of titleParts
+				--- display dialog \"Artist: \" & artistName & return & \"Track: \" & trackName
+				return artistName & \" - \" & trackName
+			else
+				--- display dialog \"Could not parse artist and track from: \" & pageTitle
+				return \"can't encode\"
+			end if
+			-- Check if it's a Spotify video page
+		else if currentURL contains \"open.spotify.com\" then
+			-- Spotify video titles usually follow this format: \"Artist • Track Name\"
+			set AppleScript's text item delimiters to \" • \"
+			set titleParts to text items of pageTitle
+
+			if (count of titleParts) ≥ 2 then
+				set artistName to item 1 of titleParts
+				set trackName to item 2 of titleParts
+				--- display dialog \"Artist: \" & artistName & return & \"Track: \" & trackName
+				return artistName & \" - \" & trackName
+			else
+				--- display dialog \"Could not parse artist and track from: \" & pageTitle
+				return \"can't encode\"
+			end if
+
+
+		else
+			return \"No active Tab\"
+		end if
+
+	end browserPlayer
+
+
+	detectPlayer()
+	")
+
+
+case "$active_player" in
+		"not running") echo "not running" ;;
+		"stopped") echo "stopped" ;;
+    "can't encode") echo "unable to encode" ;;
+    "Not Supported") echo "not supported" ;;
+
+		*) echo "$active_player" ;;
+	esac
+
+}
+
+function sliceTrack()
+{
+  local str="$1"
+  local std="$2"
+  local len=${#str}
+
+  local result=""
+
+  if [[ $len > $std ]]; then
+    result="${str:0:std}"
+    result+="..."
+  else
+    result=$str
+  fi
+
+  echo "$result"
+}
+
+
+function remoteControl() {
+  toggle_button="$1"
+  back_button="$2"
+  next_button="$3"
+  app_controlled="$4"
+
+  if [[ $app_controlled == "Spotify" ]] || [[ $app_controlled == "Music" ]]; then
+
+    toggle="osascript -e 'tell application \"$app_controlled\" to playpause'"
+    back="osascript -e 'tell application \"$app_controlled\" to back track'"
+    next="osascript -e 'tell application \"$app_controlled\" to play next track'"
+
+    tmux unbind-key "$toggle_button"
+    tmux unbind-key "$back_button"
+    tmux unbind-key "$next_button"
+
+    tmux bind-key "$toggle_button" run-shell "$toggle"
+    tmux bind-key "$back_button" run-shell "$back"
+    tmux bind-key "$next_button" run-shell "$next"
+  else
+    tmux unbind-key "$toggle_button"
+    tmux unbind-key "$back_button"
+    tmux unbind-key "$next_button"
+  fi
+}
+
+
+main() {
+  # save buffer to prevent lag
+	local cache_file="/tmp/tmux_mac_player_cache"
+
+  RATE=$(get_tmux_option "@dracula-refresh-rate" 5)
+
+  # Active Player variables
+  PLAY_ICON=$(get_tmux_option "@dracula-mac-player-play-icon" "♪")
+  PAUSE_ICON=$(get_tmux_option "@dracula-mac-player-pause" "❚❚ ")
+  MAX_LENGTH=$(get_tmux_option "@dracula-mac-player-length" 25)
+
+  # Remote variables
+  REMOTE_ACCESS=$(get_tmux_option "@dracula-mac-player-remote" false)
+  REMOTE_APP=$(get_tmux_option "@dracula-mac-player-app" "Spotify")
+
+  # Remote Control Buttons Customizations
+  PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-pp" "P")
+  BACK_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-back" "R")
+  NEXT_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-next" "N")
+
+
+
+  # os checker
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo ""
+    exit 0
+  fi
+
+  # Remote Access
+  if [[ "$REMOTE_ACCESS" == true ]]; then
+    remoteControl "$PLAY_PAUSE_BUTTON" "$BACK_BUTTON" "$NEXT_BUTTON" "$REMOTE_APP"
+
+  fi
+
+  if [ ! -f "$cache_file" ] || [ $(($(date +%s) - $(stat -f%c "$cache_file"))) -ge "$RATE" ]; then
+    trackStatus "$PAUSE_ICON" "$PLAY_ICON" > "$cache_file"
+    sliceTrack "$(cat $cache_file)" "$MAX_LENGTH" > "$cache_file"
+  fi
+
+	cat "$cache_file"
+}
+
+main
+

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -28,7 +28,6 @@ function trackStatus() {
 				else
 					return nativePlayer(currentApp)
 				end if
-			else
 			end if
 		end repeat
 
@@ -83,7 +82,7 @@ function trackStatus() {
 				set pageTitle to title of currentTab
 			end tell
 		else
-			return \"Not supported\"
+			return \"Not Supported\"
 		end if
 
 
@@ -150,7 +149,7 @@ function sliceTrack()
   local result=""
 
   if [[ $len > $std ]]; then
-    result="${str:0:std}"
+    result="${str:0:$std}"
     result+="..."
   else
     result=$str


### PR DESCRIPTION
Sorry for the delay, this is based on the enhancment pull request #336 

The following things were done based on the tasks assigned to myself:
 - [x] nativePlayer search 
      - [x] Spotify
      - [x] Apple Music - Music
      - Tidal - not natively supported for applescript
 - [x] browserPlayer (The active tab has to be youtube or spotify)
      - [x] Google Chrome
      - [x] Safari
      - Firefox ( not applescript supported )
      - Chromium and Firefox variants (arc, zed) - (not applescript supported)

Contains a remote feature but the apps only supported are:
- spotify
- music (apple music)