### PR TITLE
new battery status "Not charging" and nerdfont docs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -188,6 +188,14 @@ which will display the battery charge and whether its charging (or just drawing 
 set -g @dracula-battery-label false
 set -g @dracula-show-battery-status true
 ```
+these settings will introduce the following icons:
+- the battery is discharging and at the current level: 󰂎 󰁺 󰁻 󰁼 󰁽 󰁾 󰁿 󰂀 󰂁 󰂂 󰁹
+- the battery is charging and at the current level: 󰢟 󰢜 󰂆 󰂇 󰂈 󰢝 󰂉 󰢞 󰂊 󰂋 󰂅
+- power is being drawn from AC, but the battery is neither charging nor discharging: 
+- we were able to determine that the battery is charging/ discharging, but something about the percentage went wrong: 󰂃
+- we don't know the status of the battery: 
+
+
 
 if you have no battery and would like the widget to hide in that case, set the following:
 

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -126,7 +126,7 @@ battery_status()
       )
       echo "${battery_labels[$((bat_perc/10*10))]:-󰂃}"
       ;;
-    ACattached)
+    "ACattached"|"Not charging")
       # drawing from AC but not charging
       echo ''
       ;;


### PR DESCRIPTION
now the status "Not charging" is added and considered the same as MacOS' "ACattached", since both mean that the battery is neither charging nor discharging, but power is being drawn form AC only.
also, the icons are now described in the docs. my github still can't render them, but it's good to have it there for when people check it some other way.