### PR TITLE
feat/add gsm support

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -470,8 +470,8 @@ set -g @dracula-mpc-format "%title% - %artist%"
 
 `set -g @dracula-refresh-rate 5` affects this widget
 ### network - [up](#table-of-contents)
-This widget displays one of three states: offline, ethernet connected, or wifi connected.
-however, per default **this will only display the wifi you're connected to, if it provides internet access!**
+This widget displays one of four states: offline, ethernet connected, wifi connected, or gsm connected.
+however, per default **this will only display the ethernet/wifi/gsm you're connected to, if it provides internet access!**
 
 You can use different hosts to ping in order to check for a wifi or wired connection.
 If you frequently use networks without internet access, you can use local ip-addresses here to still display the connection.
@@ -483,14 +483,15 @@ Possible nerdfont settings for network info:
 ```bash
 set -g @dracula-network-ethernet-label "󰈀 Eth"
 set -g @dracula-network-offline-label "󱍢 "
-set -g @dracula-network-wifi-label " "
+set -g @dracula-network-wifi-label " "
+set -g @dracula-network-gsm-label " "
 ```
 
 Nerdfont icons to consider:
 ```
 ethernet: 󰈀 󰒪 󰒍 󰌗 󰌘
 offline: 󰖪  󱍢
-wifi:      󰖩  󰘊 󰒢
+wifi/gsm:      󰖩  󰘊 󰒢
 ```
 
 Known issues:

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -8,6 +8,7 @@ source $current_dir/utils.sh
 # set your own hosts so that a wifi is recognised even without internet access
 HOSTS=$(get_tmux_option "@dracula-network-hosts" "google.com github.com example.com")
 wifi_label=$(get_tmux_option "@dracula-network-wifi-label" "")
+gsm_label=$(get_tmux_option "@dracula-network-gsm-label" "GSM")
 ethernet_label=$(get_tmux_option "@dracula-network-ethernet-label" "Ethernet")
 
 get_ssid()
@@ -16,8 +17,17 @@ get_ssid()
   case $(uname -s) in
     Linux)
       SSID=$(iw dev | sed -nr 's/^\t\tssid (.*)/\1/p')
+      if [ ! -x "$(which nmcli 2> /dev/null)" ];then
+        nmcli connection show --active | grep gsm
+        gsm_connected=$?
+      else
+        gsm_connected=false
+      fi
       if [ -n "$SSID" ]; then
         echo "$wifi_label$SSID"
+      elif [ $gsm_connected ]; then
+        gsm_carrier=$(nmcli connection show --active | grep gsm | cut -d ' ' -f 1)
+        echo "$gsm_label$gsm_carrier"
       else
         echo "$ethernet_label"
       fi


### PR DESCRIPTION
network.sh now supports gsm modules via nmcli.

when connected via gsm, the gsm label is displayed in combination with the carrier.  
the gsm label can be set to something custom:
```bash
set -g @dracula-network-gsm-label " "
```

tested on:
 - [x] linux (x86) with gsm
 - [ ] linux (x86) without gsm
 - [x] MacOS (apple silicon) without gsm