### PR TITLE
feat/making plugin padding customizable

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -88,6 +88,18 @@ Hide empty plugins
 set -g @dracula-show-empty-plugins false
 ```
 
+Set plugin padding
+Whilst the padding is one space per default, can be whatever you want it to be, whether that's whitespace or other characters.
+**If you want to remove any padding, you need to use a zero width space!**
+
+```bash
+set -g @dracula-left-pad ' ° '
+set -g @dracula-right-pad ' ° '
+# no padding with zero width space
+set -g @dracula-left-pad '​'
+set -g @dracula-right-pad '​'
+```
+
 ### Powerline - [up](#table-of-contents)
 
 Enable powerline symbols

--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -38,6 +38,8 @@ main() {
   show_ssh_session_port=$(get_tmux_option "@dracula-show-ssh-session-port" false)
   show_libreview=$(get_tmux_option "@dracula-show-libreview" false)
   show_empty_plugins=$(get_tmux_option "@dracula-show-empty-plugins" true)
+  left_pad=$(get_tmux_option "@dracula-left-pad" " ")
+  right_pad=$(get_tmux_option "@dracula-right-pad" " ")
 
   narrow_mode=$(get_tmux_option "@dracula-narrow-mode" false)
   if $narrow_mode; then
@@ -361,18 +363,21 @@ main() {
       background_color=${powerbg}
     fi
 
+    # padding
+    pad_script="$left_pad$script$right_pad"
+
     if $show_powerline; then
       if $show_empty_plugins; then
-        tmux set-option -ga status-right " #[fg=${!colors[0]},bg=${background_color},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script $right_edge_icon"
+        tmux set-option -ga status-right " #[fg=${!colors[0]},bg=${background_color},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}]$pad_script$right_edge_icon"
       else
-    tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[0]},nobold,nounderscore,noitalics] ${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}] $script $right_edge_icon}"
+        tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[0]},nobold,nounderscore,noitalics]${right_sep}#[fg=${!colors[1]},bg=${!colors[0]}]$pad_script$right_edge_icon}"
     fi
       powerbg=${!colors[0]}
     else
       if $show_empty_plugins; then
-        tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}] $script "
+        tmux set-option -ga status-right "#[fg=${!colors[1]},bg=${!colors[0]}]$pad_script"
       else
-        tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[1]},bg=${!colors[0]}] $script }"
+        tmux set-option -ga status-right "#{?#{==:$script,},,#[fg=${!colors[1]},bg=${!colors[0]}]$pad_script}"
       fi
     fi
 


### PR DESCRIPTION
replace the space that would be added to the left and right of a plugin by customizable variables.
both the left and right pad variables are one space per default in order not to change the status quo and break user configs.

this enables tighter packing of plugins, by using a zero width space for padding.  
```bash
set -g @dracula-left-pad '​'  # THERE IS A ZERO WIDTH SPACE HERE
set -g @dracula-right-pad '​'  # USING '' WITHOUT A PADDING CHARACTER WON'T WORK
set -g @dracula-show-right-sep " "
set -g @dracula-show-powerline true
```
<img width="591" height="37" alt="image" src="https://github.com/user-attachments/assets/58454e6b-b99e-427e-a548-0fd100504d78" />

or fancy wide configs
```bash
set -g @dracula-show-edge-icons true
set -g @dracula-left-pad '   '
set -g @dracula-right-pad '   '
set -g @dracula-show-left-sep " "
set -g @dracula-show-right-sep " "
set -g @dracula-inverse-divider 
```
<img width="1331" height="37" alt="image" src="https://github.com/user-attachments/assets/c50a05ad-b0d8-4369-96b5-144926e4a96e" />
