### PR TITLE
feat: Hide battery widget on Desktop PCs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -219,6 +219,12 @@ alternatively, if you have no battery and would like a nerdfont icon to indicate
 set -g @dracula-no-battery-label " "
 ```
 
+if you only want to hide the battery widget on a desktop pc, set the following:
+
+```bash
+set -g @dracula-battery-hide-on-desktop true
+```
+
 ### compact-alt - [up](#table-of-contents)
 
 This widget allows the user to switch to an alternate list of widgets when the terminal becomes narrow.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -222,6 +222,7 @@ set -g @dracula-no-battery-label " "
 if you only want to hide the battery widget on a desktop pc, set the following:
 
 ```bash
+# default is false
 set -g @dracula-battery-hide-on-desktop true
 ```
 

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -181,7 +181,7 @@ main()
 
   if [ -z "$bat_stat" ]; then # Test if status is empty or not
     echo "$bat_label $bat_perc"
-  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percentage, only AC power
+  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
     echo "$no_bat_label"
   else
     echo "$bat_label$bat_stat $bat_perc"

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -181,6 +181,8 @@ main()
 
   if [ -z "$bat_stat" ]; then # Test if status is empty or not
     echo "$bat_label $bat_perc"
+  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percentage, only AC power
+    echo "$no_bat_label"
   else
     echo "$bat_label$bat_stat $bat_perc"
   fi

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -5,7 +5,6 @@ export LC_ALL=en_US.UTF-8
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 
-
 linux_acpi() {
   arg=$1
   BAT=$(ls -d /sys/class/power_supply/*)

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -5,7 +5,6 @@ export LC_ALL=en_US.UTF-8
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 
-hide_status_on_desktop="$(get_tmux_option "@dracula-battery-hide-status-on-desktop" "false")"
 
 linux_acpi() {
   arg=$1
@@ -174,8 +173,9 @@ main()
 
   bat_perc=$(battery_percent)
 
+  hide_on_desktop="$(get_tmux_option "@dracula-battery-hide-on-desktop" "false")"
   # If no battery percent, don't show anything
-  if [ -z "$bat_perc" ] && [ "$hide_status_on_desktop" = "true" ]; then
+  if [ -z "$bat_perc" ] && [ "$hide_on_desktop" = "true" ]; then
       echo ""
       return
   fi

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -5,6 +5,8 @@ export LC_ALL=en_US.UTF-8
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 
+hide_status_on_desktop="$(get_tmux_option "@dracula-battery-hide-status-on-desktop" "false")"
+
 linux_acpi() {
   arg=$1
   BAT=$(ls -d /sys/class/power_supply/*)
@@ -172,10 +174,14 @@ main()
 
   bat_perc=$(battery_percent)
 
-  if [ -z "$bat_stat" ]; then # Test if status is empty or not
+  # If no battery percent, don't show anything
+  if [ -z "$bat_perc" ] && [ "$hide_status_on_desktop" = "true" ]; then
+      echo ""
+      return
+  fi
+
+  if [ -z "$bat_stat" ]; then
     echo "$bat_label $bat_perc"
-  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
-    echo "$no_bat_label"
   else
     echo "$bat_label$bat_stat $bat_perc"
   fi

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -179,7 +179,7 @@ main()
       return
   fi
 
-  if [ -z "$bat_stat" ]; then
+  if [ -z "$bat_stat" ]; then # Test if status is empty or not
     echo "$bat_label $bat_perc"
   else
     echo "$bat_label$bat_stat $bat_perc"


### PR DESCRIPTION
Checks to see if there is no battery and if `@dracula-battery-hide-on-desktop"` is true it will hide the battery widget.

Useful for when a config is shared between a Laptop and a Desktop and only have the battery hidden on the Desktop