### PR TITLE
fix: Hide when on a desktop

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -219,13 +219,6 @@ alternatively, if you have no battery and would like a nerdfont icon to indicate
 set -g @dracula-no-battery-label " "
 ```
 
-if you only want to hide the battery widget on a desktop pc, set the following:
-
-```bash
-# default is false
-set -g @dracula-battery-hide-on-desktop true
-```
-
 ### compact-alt - [up](#table-of-contents)
 
 This widget allows the user to switch to an alternate list of widgets when the terminal becomes narrow.

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -175,7 +175,12 @@ main()
   if [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
     echo "$no_bat_label"
   elif [ -z "$bat_stat" ]; then # Test if status is empty or not
-    echo "$bat_label $bat_perc"
+    # Only add a space when label is not empty
+    if [ -n "$bat_label" ]; then
+      echo "$bat_label $bat_perc"
+    else
+      echo "$bat_perc"
+    fi
   else
     echo "$bat_label$bat_stat $bat_perc"
   fi

--- a/scripts/battery.sh
+++ b/scripts/battery.sh
@@ -172,17 +172,10 @@ main()
 
   bat_perc=$(battery_percent)
 
-  hide_on_desktop=$(get_tmux_option "@dracula-battery-hide-on-desktop" false)
-  # If no battery percent and the feature flag is enabled, hide the widget completely
-  if $hide_on_desktop && [ -z "$bat_perc" ]; then
-      echo ""
-      return
-  fi
-
-  if [ -z "$bat_stat" ]; then # Test if status is empty or not
-    echo "$bat_label $bat_perc"
-  elif [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
+  if [ -z "$bat_perc" ]; then # In case it is a desktop with no battery percent, only AC power
     echo "$no_bat_label"
+  elif [ -z "$bat_stat" ]; then # Test if status is empty or not
+    echo "$bat_label $bat_perc"
   else
     echo "$bat_label$bat_stat $bat_perc"
   fi


### PR DESCRIPTION
Moved the check of the battery percentage to the top as it was always hitting the $bat_stat check making it to never hide the label and always display a <3