### PR TITLE
patch: spotify and apple-music backtrack conflicts with remote control and display optimizations

### DIFF
--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -178,10 +178,6 @@ function remoteControl() {
     tmux bind-key "$toggle_button" run-shell "$toggle"
     tmux bind-key "$back_button" run-shell "$back"
     tmux bind-key "$next_button" run-shell "$next"
-  else
-    tmux unbind-key "$toggle_button"
-    tmux unbind-key "$back_button"
-    tmux unbind-key "$next_button"
   fi
 }
 
@@ -217,7 +213,10 @@ main() {
   # Remote Access
   if [[ "$REMOTE_ACCESS" == true ]]; then
     remoteControl "$PLAY_PAUSE_BUTTON" "$BACK_BUTTON" "$NEXT_BUTTON" "$REMOTE_APP"
-
+  else
+    tmux unbind-key "$toggle_button"
+    tmux unbind-key "$back_button"
+    tmux unbind-key "$next_button"
   fi
 
   if [ ! -f "$cache_file" ] || [ $(($(date +%s) - $(stat -f%c "$cache_file"))) -ge "$RATE" ]; then

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -203,7 +203,6 @@ main() {
 
   # os checker
   if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo ""
     exit 1
   fi
 

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -167,8 +167,12 @@ function remoteControl() {
 
   if [[ $app_controlled == "Spotify" ]] || [[ $app_controlled == "Music" ]]; then
 
+    if [[ $app_controlled == "Music" ]]; then
+      back="osascript -e 'tell application \"$app_controlled\" to back track'"
+    else
+      back="osascript -e 'tell application \"$app_controlled\" to set player position to 0'"
+    fi
     toggle="osascript -e 'tell application \"$app_controlled\" to playpause'"
-    back="osascript -e 'tell application \"$app_controlled\" to back track'"
     next="osascript -e 'tell application \"$app_controlled\" to play next track'"
 
     tmux unbind-key "$toggle_button"

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -198,15 +198,8 @@ main() {
   MAX_LENGTH=$(get_tmux_option "@dracula-mac-player-length" 25)
 
   # Remote variables
-  REMOTE_ACCESS=$(get_tmux_option "@dracula-mac-player-remote" false)
+  REMOTE_ACCESS=$(get_tmux_option "@dracula-mac-player-remote" "false")
   REMOTE_APP=$(get_tmux_option "@dracula-mac-player-app" "Spotify")
-
-  # Remote Control Buttons Customizations
-  PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-play-pause" "P")
-  BACK_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-back" "R")
-  NEXT_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-next" "N")
-
-
 
   # os checker
   if [[ "$OSTYPE" != "darwin"* ]]; then
@@ -215,12 +208,12 @@ main() {
   fi
 
   # Remote Access
-  if [[ "$REMOTE_ACCESS" == true ]]; then
+  if [[ "$REMOTE_ACCESS" == "true" ]]; then
+    # Remote Control Buttons Customizations
+    PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-play-pause" "P")
+    BACK_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-back" "R")
+    NEXT_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-next" "N")
     remoteControl "$PLAY_PAUSE_BUTTON" "$BACK_BUTTON" "$NEXT_BUTTON" "$REMOTE_APP"
-  else
-    tmux unbind-key "$toggle_button"
-    tmux unbind-key "$back_button"
-    tmux unbind-key "$next_button"
   fi
 
   if [ ! -f "$cache_file" ] || [ $(($(date +%s) - $(stat -f%c "$cache_file"))) -ge "$RATE" ]; then

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -217,8 +217,9 @@ main() {
   fi
 
   if [ ! -f "$cache_file" ] || [ $(($(date +%s) - $(stat -f%c "$cache_file"))) -ge "$RATE" ]; then
-    trackStatus "$PAUSE_ICON" "$PLAY_ICON" > "$cache_file"
-    sliceTrack "$(cat $cache_file)" "$MAX_LENGTH" > "$cache_file"
+    local full_track
+    full_track=$(trackStatus "$PAUSE_ICON" "$PLAY_ICON")
+    sliceTrack "$full_track" "$MAX_LENGTH" > "$cache_file"
   fi
 
 	cat "$cache_file"

--- a/scripts/mac-player.sh
+++ b/scripts/mac-player.sh
@@ -172,6 +172,7 @@ function remoteControl() {
     else
       back="osascript -e 'tell application \"$app_controlled\" to set player position to 0'"
     fi
+
     toggle="osascript -e 'tell application \"$app_controlled\" to playpause'"
     next="osascript -e 'tell application \"$app_controlled\" to play next track'"
 
@@ -212,11 +213,13 @@ main() {
     PLAY_PAUSE_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-play-pause" "P")
     BACK_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-back" "R")
     NEXT_BUTTON=$(get_tmux_option "@dracula-mac-player-remote-next" "N")
+
     remoteControl "$PLAY_PAUSE_BUTTON" "$BACK_BUTTON" "$NEXT_BUTTON" "$REMOTE_APP"
   fi
 
   if [ ! -f "$cache_file" ] || [ $(($(date +%s) - $(stat -f%c "$cache_file"))) -ge "$RATE" ]; then
     local full_track
+
     full_track=$(trackStatus "$PAUSE_ICON" "$PLAY_ICON")
     sliceTrack "$full_track" "$MAX_LENGTH" > "$cache_file"
   fi


### PR DESCRIPTION
This patch contains solutions to errors (which were caused by my bad coding):
 - the back track option for applescript is only for apple-music but spotify it doesn't have it. I've added a guard to the back variable thus the spotify option is set to position 0.
 - boolean values patched to strings
 - cache optimizations
 - not overusing the cat command